### PR TITLE
Rename decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ A utility for mocking out the Python [HTTPX](https://github.com/encode/httpx) li
 import httpx
 import respx
 
-@respx.activate
+@respx.mock
 def test_something():
     request = respx.post("https://foo.bar/baz/", status_code=201)
     response = httpx.post("https://foo.bar/baz/")
     assert request.called
     assert response.status_code == 201
 
-with respx.activate():
+with respx.mock():
     request = respx.get("https://foo.bar/", content={"foo": "bar"})
     response = httpx.get("https://foo.bar/")
     assert request.called

--- a/respx/mock.py
+++ b/respx/mock.py
@@ -20,6 +20,8 @@ except ImportError:  # pragma: nocover
 
 _get_response = BaseClient._get_response  # Pass-through reference
 
+__all__ = ["HTTPXMock"]
+
 
 class HTTPXMock:
     def __init__(self, assert_all_called: bool = True) -> None:
@@ -47,7 +49,7 @@ class HTTPXMock:
             self.assert_all_called()
         self.clear()
 
-    def activate(self, func=None):
+    def mock(self, func=None):
         """
         Starts mocking and stops once wrapped function, or context, is executed.
         """

--- a/respx/mock.py
+++ b/respx/mock.py
@@ -210,8 +210,6 @@ class HTTPXMock:
             with self._patch_backend(client.concurrency_backend):
                 response = None
                 response = await _get_response(client, request, **kwargs)
-        except Exception as e:
-            raise e
         finally:
             # 4. Update stats
             if pattern:

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -30,16 +30,16 @@ class HTTPXMockTestCase(asynctest.TestCase):
         respx.clear()
         self.assertEqual(len(respx.calls), 0)
 
-    @respx.activate
-    def test_activate_decorator(self):
+    @respx.mock
+    def test_mock_decorator(self):
         respx.get("https://foo/bar/", status_code=202)
         response = httpx.get("https://foo/bar/")
         self.assertEqual(response.status_code, 202)
 
-    def test_activate_contextmanager(self):
+    def test_mock_contextmanager(self):
         self.assertEqual(len(respx.calls), 0)
 
-        with respx.activate():
+        with respx.mock():
             respx.get("https://foo/bar/", status_code=202)
             response = httpx.get("https://foo/bar/")
 
@@ -98,7 +98,7 @@ class HTTPXMockTestCase(asynctest.TestCase):
         self.assertEqual(response.text, "whatever")
 
     def test_invalid_url_pattern(self):
-        with respx.activate():
+        with respx.mock():
             foobar = respx.get(["invalid"], content="whatever")
             with self.assertRaises(ValueError):
                 httpx.get("https://foo/bar/")
@@ -106,7 +106,7 @@ class HTTPXMockTestCase(asynctest.TestCase):
         self.assertFalse(foobar.called)
 
     def test_unknown_url(self):
-        with respx.activate():
+        with respx.mock():
             url = "https://foo/bar/"
             foobar = respx.post(url)  # Non-matching method
             response = httpx.get(url)
@@ -280,7 +280,7 @@ class HTTPXMockTestCase(asynctest.TestCase):
         self.assertEqual(response.text, "foobar")
 
     def test_alias(self):
-        with respx.activate() as m:
+        with respx.mock() as m:
             url = "https://foo/bar/"
             foobar = respx.get(url, alias="foobar")
             self.assertIn("foobar", respx.aliases)
@@ -356,7 +356,7 @@ class HTTPXMockTestCase(asynctest.TestCase):
             self.assertTrue(request2.called)
 
     async def test_stats(self, backend=None):
-        with respx.activate():
+        with respx.mock():
             url = "https://foo/bar/1/"
             respx.get(re.compile("http://some/url"))
             respx.delete("http://some/url")


### PR DESCRIPTION
Renames the decorator and contextmanager `activate` -> `mock` to be a little bit more descriptive.