### PR TITLE
Configurable decorator and context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,34 +25,33 @@ def test_something():
     response = httpx.post("https://foo.bar/baz/")
     assert request.called
     assert response.status_code == 201
+
+
+@respx.mock(assert_all_mocked=False)
+def test_something(httpx_mock):
+    response = httpx.post("https://foo.bar/baz/")
+    assert response.status_code == 200
+
 ```
 
 
 ## Context Manager
 
-Using the high-level api:
-
 ```py
 import httpx
 import respx
 
 
-with respx.mock():
+with respx.mock:
     request = respx.get("https://foo.bar/", content={"foo": "bar"})
     response = httpx.get("https://foo.bar/")
     assert request.called
     assert response.json() == {"foo": "bar"}
-```
-
-Using the low-level api:
-
-```py
-import httpx
-import respx
 
 
-with respx.HTTPXMock() as respx_mock:
-    request = respx_mock.get("https://foo.bar/", content={"foo": "bar"})
+with respx.mock(assert_all_called=False) as httpx_mock:
+    httpx_mock.get("https://ham.spam/")
+    request = httpx_mock.get("https://foo.bar/", content={"foo": "bar"})
     response = httpx.get("https://foo.bar/")
     assert request.called
     assert response.json() == {"foo": "bar"}

--- a/respx/__init__.py
+++ b/respx/__init__.py
@@ -1,10 +1,10 @@
 # type: ignore
 from .mock import HTTPXMock
 
-__all__ = ["HTTPXMock"]
-
 # Expose mock api
-__httpx_mock = HTTPXMock(assert_all_called=False)
-__api_methods = list(filter(lambda m: not m.startswith("_"), dir(__httpx_mock)))
-__all__.extend(__api_methods)
-globals().update({method: getattr(__httpx_mock, method) for method in __api_methods})
+mock = HTTPXMock(assert_all_called=False, local=False)
+__api__ = list(filter(lambda m: not m.startswith("_"), dir(mock)))
+
+__all__ = ["HTTPXMock", "mock"]
+__all__.extend(__api__)
+globals().update({method: getattr(mock, method) for method in __api__})

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ force_grid_wrap = 0
 not_skip = __init__.py
 
 [coverage:run]
-source = respx
+source = respx,tests
 branch = True
 
 [coverage:report]


### PR DESCRIPTION
Allows the `respx.mock` decorator and context manager to configure the mock.

```py
@respx.mock(assert_all_mocked=True)
def test_something(httpx_mock):
    httpx_mock.get(...)
    httpx.get(...)

with respx.mock(assert_all_called=False) as httpx_mock:
    httpx_mock.get(...)
    httpx.get(...)
```

### Note
This PR **breaks** any previous usage of the context manager `with respx.mock():`, *with parentheses*, together with the global `respx.stats`.