### PR TITLE
Add support for configuring pattern base url

### DIFF
--- a/respx/api.py
+++ b/respx/api.py
@@ -23,11 +23,13 @@ class HTTPXMock:
         self,
         assert_all_called: bool = True,
         assert_all_mocked: bool = True,
+        base_url: typing.Optional[str] = None,
         local: bool = True,
     ) -> None:
         self._is_local = local
         self._assert_all_called = assert_all_called
         self._assert_all_mocked = assert_all_mocked
+        self._base_url = base_url
         self._patchers: typing.List[asynctest.mock._patch] = []
         self._patterns: typing.List[RequestPattern] = []
         self.aliases: typing.Dict[str, RequestPattern] = {}
@@ -39,6 +41,7 @@ class HTTPXMock:
         func: typing.Optional[typing.Callable] = None,
         assert_all_called: typing.Optional[bool] = None,
         assert_all_mocked: typing.Optional[bool] = None,
+        base_url: typing.Optional[str] = None,
     ) -> typing.Union["HTTPXMock", typing.Callable]:
         """
         Decorator or Context Manager.
@@ -50,7 +53,7 @@ class HTTPXMock:
             # A. First stage of "local" decorator, WITH parentheses.
             # B. Only stage of "local" context manager, WITH parentheses,
             #    "global" context maanager hits __enter__ directly.
-            settings = {}
+            settings: typing.Dict[str, typing.Any] = {"base_url": base_url}
             if assert_all_called is not None:
                 settings["assert_all_called"] = assert_all_called
             if assert_all_mocked is not None:
@@ -161,7 +164,12 @@ class HTTPXMock:
 
         response = ResponseTemplate(status_code, headers, content)
         pattern = RequestPattern(
-            method, url, response, pass_through=pass_through, alias=alias
+            method,
+            url,
+            response,
+            pass_through=pass_through,
+            alias=alias,
+            base_url=self._base_url,
         )
 
         self.add(pattern, alias=alias)

--- a/respx/models.py
+++ b/respx/models.py
@@ -121,6 +121,7 @@ class RequestPattern:
     def set_url(
         self, url: typing.Optional[URLPatternTypes], base: typing.Optional[str] = None,
     ) -> None:
+        url = url or None
         if url is None:
             url = url if base is None else base
         elif isinstance(url, str):
@@ -160,10 +161,12 @@ class RequestPattern:
         if self.method != request.method:
             return None
 
-        if isinstance(self.url, str):
-            matches = self.url == str(request.url)
+        if not self._url:
+            matches = True
+        elif isinstance(self._url, str):
+            matches = self._url == str(request.url)
         else:
-            match = self.url.match(str(request.url))
+            match = self._url.match(str(request.url))
             if match:
                 matches = True
                 url_params = match.groupdict()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,7 +41,7 @@ async def test_http_methods():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "url", ["https://foo.bar/baz/", re.compile(r"^https://foo.bar/\w+/$")]
+    "url", [None, "", "https://foo.bar/baz/", re.compile(r"^https://foo.bar/\w+/$")]
 )
 async def test_url_match(url):
     async with respx.HTTPXMock(assert_all_mocked=False) as httpx_mock:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,11 +54,9 @@ async def test_url_match(url):
 
 @pytest.mark.asyncio
 async def test_invalid_url_pattern():
-    async with respx.HTTPXMock(assert_all_called=False) as httpx_mock:
-        request = httpx_mock.get(["invalid"])
+    async with respx.HTTPXMock() as httpx_mock:
         with pytest.raises(ValueError):
-            await httpx.get("https://foo.bar/")
-        assert request.called is False
+            httpx_mock.get(["invalid"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -23,6 +23,7 @@ async def test_alias():
 @pytest.mark.asyncio
 async def test_httpx_exception_handling():
     async with respx.HTTPXMock() as httpx_mock:
+        # TODO: Patch something else once HTTPX 0.8.1 is released
         with asynctest.mock.patch(
             "httpx.client.Client._dispatcher_for_request",
             side_effect=ValueError("mock"),
@@ -43,9 +44,9 @@ async def test_httpx_exception_handling():
 def test_stats(Backend):
     @respx.mock
     async def test(backend):
-        url = "https://foo/bar/1/"
-        respx.get(re.compile("http://some/url"))
-        respx.delete("http://some/url")
+        url = "https://foo.bar/1/"
+        respx.get(re.compile("https://some.thing"))
+        respx.delete("https://some.thing")
 
         foobar1 = respx.get(url, status_code=202, alias="get_foobar")
         foobar2 = respx.delete(url, status_code=200, alias="del_foobar")


### PR DESCRIPTION
```py
base_url = "https://foo.bar/"

async with respx.mock(base_url=base_url) as httpx_mock:
    httpx_mock.get("/", content="hello")
    async with httpx.Client(base_url=base_url) as client:
        response = await client.get("/")
        assert response.text == "hello"
```