### PR TITLE
Add support for nested and parallel mocking

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ def test(session):
     session.install("-e", ".")
 
     options = session.posargs
-    if "-k" in options:
+    if "-k" in options or "-x" in options:
         options.append("--no-cov")
 
     session.run("pytest", "-v", *options)

--- a/respx/__init__.py
+++ b/respx/__init__.py
@@ -2,7 +2,7 @@ from .__version__ import __version__
 from .api import HTTPXMock
 
 # Expose mock api
-mock = HTTPXMock(assert_all_called=False, local=False)
+mock = HTTPXMock(assert_all_called=False)
 __api__ = list(filter(lambda m: not m.startswith("_"), dir(mock)))
 
 __all__ = ["__version__", "HTTPXMock", "mock"]

--- a/respx/fixtures.py
+++ b/respx/fixtures.py
@@ -1,6 +1,6 @@
 try:
     import pytest
-except ImportError:
+except ImportError:  # pragma: nocover
     pass
 else:
     import asyncio

--- a/respx/fixtures.py
+++ b/respx/fixtures.py
@@ -1,0 +1,12 @@
+try:
+    import pytest
+except ImportError:
+    pass
+else:
+    import asyncio
+
+    @pytest.fixture(scope="session")
+    def session_event_loop():
+        loop = asyncio.get_event_loop_policy().new_event_loop()
+        yield loop
+        loop.close()

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,5 +47,8 @@ warn_redundant_casts = True
 warn_unused_ignores = True
 warn_unreachable = True
 
+[mypy-pytest.*]
+ignore_missing_imports = True
+
 [mypy-asynctest.*]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     python_requires=">=3.6",
-    install_requires=["httpx==0.11.0", "asynctest"],
+    install_requires=["httpx>=0.11,<0.12", "asynctest"],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,20 +5,38 @@ import pytest
 
 import respx
 
-
-@pytest.yield_fixture
-async def httpx_mock():
-    async with respx.HTTPXMock() as httpx_mock:
-        yield httpx_mock
+pytestmark = pytest.mark.asyncio
 
 
-@pytest.fixture
-def future():
-    loop = asyncio.get_event_loop()
-    return loop.run_until_complete
+@pytest.fixture(scope="session")
+def event_loop():
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()
 
 
 @pytest.fixture
 async def client():
     async with httpx.AsyncClient() as client:
         yield client
+
+
+@pytest.fixture
+async def httpx_mock():
+    async with respx.mock(base_url="https://httpx.mock") as httpx_mock:
+        httpx_mock.get("/", status_code=404, alias="index")
+        yield httpx_mock
+
+
+@pytest.fixture(scope="session")
+async def mocked_foo(event_loop):
+    async with respx.mock(base_url="https://foo.api") as httpx_mock:
+        httpx_mock.get("/", status_code=202, alias="index")
+        yield httpx_mock
+
+
+@pytest.fixture(scope="session")
+async def mocked_ham(event_loop):
+    async with respx.mock(base_url="https://ham.api") as httpx_mock:
+        httpx_mock.get("/", status_code=200, alias="index")
+        yield httpx_mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,8 @@
-import asyncio
-
 import httpx
 import pytest
 
 import respx
-
-pytestmark = pytest.mark.asyncio
-
-
-@pytest.fixture(scope="session")
-def event_loop():
-    loop = asyncio.get_event_loop_policy().new_event_loop()
-    yield loop
-    loop.close()
+from respx.fixtures import session_event_loop as event_loop  # noqa
 
 
 @pytest.fixture
@@ -29,14 +19,15 @@ async def httpx_mock():
 
 
 @pytest.fixture(scope="session")
-async def mocked_foo(event_loop):
+async def mocked_foo():
     async with respx.mock(base_url="https://foo.api") as httpx_mock:
         httpx_mock.get("/", status_code=202, alias="index")
+        httpx_mock.get("/bar/", alias="bar")
         yield httpx_mock
 
 
 @pytest.fixture(scope="session")
-async def mocked_ham(event_loop):
+async def mocked_ham():
     async with respx.mock(base_url="https://ham.api") as httpx_mock:
         httpx_mock.get("/", status_code=200, alias="index")
         yield httpx_mock

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -32,9 +32,19 @@ async def test_mock_request_fixture(client, httpx_mock):
 
 
 @pytest.mark.asyncio
-async def test_mock_session_fixture(client, mocked_foo, mocked_ham):
-    assert mocked_foo.stats.call_count == 0
-    assert mocked_ham.stats.call_count == 0
+async def test_mock_single_session_fixture(client, mocked_foo):
+    current_foo_call_count = mocked_foo.stats.call_count
+    response = await client.get("https://foo.api/bar/")
+    request = mocked_foo.aliases["bar"]
+    assert request.called is True
+    assert response.status_code == 200
+    assert mocked_foo.stats.call_count == current_foo_call_count + 1
+
+
+@pytest.mark.asyncio
+async def test_mock_multiple_session_fixtures(client, mocked_foo, mocked_ham):
+    current_foo_call_count = mocked_foo.stats.call_count
+    current_ham_call_count = mocked_ham.stats.call_count
 
     response = await client.get("https://foo.api/")
     request = mocked_foo.aliases["index"]
@@ -46,8 +56,8 @@ async def test_mock_session_fixture(client, mocked_foo, mocked_ham):
     assert request.called is True
     assert response.status_code == 200
 
-    assert mocked_foo.stats.call_count == 1
-    assert mocked_ham.stats.call_count == 1
+    assert mocked_foo.stats.call_count == current_foo_call_count + 1
+    assert mocked_ham.stats.call_count == current_ham_call_count + 1
 
 
 def test_global_sync_decorator():


### PR DESCRIPTION
Sometimes it is useful to set up a separate `respx.mock()` per mocked API.  
This is especially useful when using pytest yield fixtures to set up respx.

Current version does not support this, since each respx mock instance unwantedly (re)patches HTTPX with it's own patterns, and could therefore fail the built-in assertion checks; `assert_all_called` and `assert_all_mocked`.

This **PR** solves this issue without breaking the api.

