### PR TITLE
Spelling error fix

### DIFF
--- a/docs/mocking.md
+++ b/docs/mocking.md
@@ -54,7 +54,7 @@ import respx
 @pytest.fixture
 def mocked_api():
     with respx.mock(base_url="https://foo.bar") as httpx_mock:
-        httpx_mock.get("/user/", content=[], alias="list_users")
+        httpx_mock.get("/users/", content=[], alias="list_users")
         ...
         yield httpx_mock
 ```


### PR DESCRIPTION
I assume that it was intended for both the mock endpoint and the user endpoint to be the same(`/users/`).  Apologies if it was intentional to create a failing test.