### PR TITLE
Include license file in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include CHANGELOG.md
+include LICENSE.md
 include respx/py.typed


### PR DESCRIPTION
In keeping with the terms of the BSD-3-Clause license, it might be good to include the license file with the source distribution