### PR TITLE
Require httpx 0.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     python_requires=">=3.6",
-    install_requires=["httpx>=0.12,<0.13", "asynctest"],
+    install_requires=["httpx>=0.13,<0.14", "asynctest"],
 )


### PR DESCRIPTION
This PR is really an issue in the form of a PR to demonstrate RESPX does not yet support the new httpx 0.13 release. 

The internal concurrency `_backends` was dropped from httpx in https://github.com/encode/httpx/pull/901.

Example tests failure:

* https://github.com/hugovk/respx/runs/702618287?check_suite_focus=true

httpx 0.13 is intended to be the last before the 1.0 release:

* https://twitter.com/_tomchristie/status/1263789740337364992