### PR TITLE
Run GitHub Actions on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Prevents the problem that PRs from forks never run and hang at "Expected — Waiting for status to be reported"

For example see https://github.com/lundberg/respx/pull/54 and https://github.com/lundberg/respx/pull/48:

![image](https://user-images.githubusercontent.com/1324225/82789821-a41ccd00-9e73-11ea-8f98-2bf270a2dabb.png)
