### PR TITLE
Refactor to transport api for httpx 0.13 support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,16 +22,16 @@ See [Request API](#request-api) for parameters.
 > <code>respx.<strong>delete</strong>(...)</strong></code>
 
 
-### Request API
+### Pattern API
 
-For full control, use the core request method.
+For full control, use the core `add` method.
 
-> ::: respx.request
+> ::: respx.add
 >     :docstring:
 >
 > **Parameters:**
 >
-> * **method** - *str | callable*  
+> * **method** - *str | callable | RequestPattern*  
 >   Request HTTP method, or [Request callback](#request-callback), to match.
 > * **url** - *(optional) str | pattern*  
 >   Request exact URL, or [URL pattern](#url-pattern), to match.
@@ -94,9 +94,9 @@ import respx
 
 
 @respx.mock(base_url="https://foo.bar")
-async def test_something():
+async def test_something(respx_mock):
     async with httpx.AsyncClient(base_url="https://foo.bar") as client:
-        request = respx.get("/baz/", content="Baz")
+        request = respx_mock.get("/baz/", content="Baz")
         response = await client.get("/baz/")
         assert response.text == "Baz"
 ```
@@ -105,7 +105,7 @@ async def test_something():
 ### Request callback
 
 For full control of what request to **match** and what response to **mock**,
-pass a *callback* function as the `request(method, ...)` parameter.
+pass a *callback* function as the `add(method, ...)` parameter.
 The callback's response argument will be pre-populated with any additional response parameters.
 
 ``` python
@@ -132,7 +132,7 @@ def match_and_mock(request, response):
 
 @respx.mock
 def test_something():
-    custom_request = respx.request(match_and_mock, status_code=201)
+    custom_request = respx.add(match_and_mock, status_code=201)
     respx.get("https://foo.bar/baz/")
 
     response = httpx.get("https://foo.bar/baz/")
@@ -254,19 +254,19 @@ Configure checks by using the `respx.mock` decorator / context manager *with* pa
 
 ``` python
 @respx.mock(assert_all_called=False)
-def test_something(httpx_mock):
-    httpx_mock.get("https://some.url/")  # OK
-    httpx_mock.get("https://foo.bar/")
+def test_something(respx_mock):
+    respx_mock.get("https://some.url/")  # OK
+    respx_mock.get("https://foo.bar/")
 
     response = httpx.get("https://foo.bar/")
     assert response.status_code == 200
-    assert httpx_mock.stats.call_count == 1
+    assert respx_mock.stats.call_count == 1
 ```
 ``` python
-with respx.mock(assert_all_mocked=False) as httpx_mock:
+with respx.mock(assert_all_mocked=False) as respx_mock:
     response = httpx.get("https://foo.bar/")  # OK
     assert response.status_code == 200
-    assert httpx_mock.stats.call_count == 1
+    assert respx_mock.stats.call_count == 1
 ```
 
 !!! attention "Without Parentheses"

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,13 +5,13 @@
 [![PyPi Version](https://img.shields.io/pypi/v/respx.svg)](https://pypi.org/project/respx/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/respx.svg)](https://pypi.org/project/respx/)
 
-A utility for mocking out the Python [HTTPX](https://www.encode.io/httpx/) library.
+A utility for mocking out the Python [HTTPX](https://www.encode.io/httpx/) and [HTTP Core](https://www.encode.io/httpcore/) libraries.
 
 ---
 
 ## QuickStart
 
-Start by mocking out `HTTPX`, using `respx.mock`, and then add desired request patterns to mock your responses.
+Start by mocking out `HTTPX` *and/or* `HTTP Core`, using `respx.mock`, and then add desired request patterns to mock your responses.
 
 ``` python
 import httpx
@@ -30,6 +30,9 @@ def test_something():
 
 The [QuickStart](#quickstart) section covers the basics. Continue reading in detail on how [Mocking HTTPX](mocking.md) is done, or head over to the [Developer Interface](api.md) for a complete guide on how to mock your responses.
 
+!!! tip
+    You can use `RESPX` not only to mock out `HTTPX`, but to actually mock responses for any library using `HTTP Core`.
+
 ## Installation
 
 Install with pip:
@@ -38,5 +41,5 @@ Install with pip:
 $ pip install respx
 ```
 
-Requires Python 3.6+ and HTTPX 0.12.0+.
+Requires Python 3.6+ and HTTPX 0.13.0+.
 See [Changelog](https://github.com/lundberg/respx/blob/master/CHANGELOG.md) for older HTTPX compatibility.

--- a/respx/__init__.py
+++ b/respx/__init__.py
@@ -1,5 +1,6 @@
 from .__version__ import __version__
-from .mocks import HTTPXMock
+from .mocks import HTTPXMock, MockTransport
+from .transports import AsyncMockTransport, SyncMockTransport
 
 from .api import (  # isort:skip
     mock,
@@ -10,6 +11,7 @@ from .api import (  # isort:skip
     stop,
     clear,
     reset,
+    add,
     request,
     get,
     post,
@@ -22,6 +24,9 @@ from .api import (  # isort:skip
 
 __all__ = [
     "__version__",
+    "MockTransport",
+    "AsyncMockTransport",
+    "SyncMockTransport",
     "HTTPXMock",
     "mock",
     "aliases",
@@ -31,6 +36,7 @@ __all__ = [
     "stop",
     "clear",
     "reset",
+    "add",
     "request",
     "get",
     "post",

--- a/respx/api.py
+++ b/respx/api.py
@@ -1,11 +1,9 @@
 from typing import Callable, Optional, Pattern, Union
 
-from httpx._models import HeaderTypes
+from .mocks import MockTransport
+from .models import ContentDataTypes, HeaderTypes, RequestPattern
 
-from .mocks import HTTPXMock
-from .models import ContentDataTypes, RequestPattern
-
-mock = HTTPXMock(assert_all_called=False)
+mock = MockTransport(assert_all_called=False)
 
 aliases = mock.aliases
 stats = mock.stats
@@ -30,6 +28,29 @@ def clear() -> None:
 def reset() -> None:
     global mock
     mock.reset()
+
+
+def add(
+    method: Union[str, Callable],
+    url: Optional[Union[str, Pattern]] = None,
+    status_code: Optional[int] = None,
+    content: Optional[ContentDataTypes] = None,
+    content_type: Optional[str] = None,
+    headers: Optional[HeaderTypes] = None,
+    pass_through: bool = False,
+    alias: Optional[str] = None,
+) -> RequestPattern:
+    global mock
+    return mock.add(
+        method,
+        url=url,
+        status_code=status_code,
+        content=content,
+        content_type=content_type,
+        headers=headers,
+        pass_through=pass_through,
+        alias=alias,
+    )
 
 
 def request(

--- a/respx/mocks.py
+++ b/respx/mocks.py
@@ -1,50 +1,46 @@
 import inspect
-import ssl
-import typing
-from contextlib import contextmanager
+import warnings
 from functools import partial, wraps
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import asynctest
-from httpx import AsyncClient, Client, Headers, Request, Response, Timeout
-from httpx._backends.base import BaseSocketStream, ConcurrencyBackend
-from httpx._dispatch.base import AsyncDispatcher, SyncDispatcher
-from httpx._models import HeaderTypes
 
-from .models import ContentDataTypes, RequestPattern, ResponseTemplate, URLResponse
+from .transports import BaseMockTransport
 
-__all__ = ["HTTPXMock"]
-
-# Pass-through references
-_Client__send = Client.send
-_AsyncClient__send = AsyncClient.send
+__all__ = ["MockTransport", "HTTPXMock"]
 
 
-class HTTPXMock:
+class MockTransport(BaseMockTransport):
+    _patches: List[asynctest.mock._patch] = []
+    transports: List["MockTransport"] = []
+    targets = [
+        "httpcore._sync.connection.SyncHTTPConnection.request",
+        "httpcore._sync.connection_pool.SyncConnectionPool.request",
+        "httpcore._async.connection.AsyncHTTPConnection.request",
+        "httpcore._async.connection_pool.AsyncConnectionPool.request",
+        "httpx._transports.asgi.ASGITransport.request",
+        "httpx._transports.wsgi.WSGITransport.request",
+        "httpx._transports.urllib3.URLLib3Transport.request",
+    ]
+
     def __init__(
         self,
         assert_all_called: bool = True,
         assert_all_mocked: bool = True,
-        base_url: typing.Optional[str] = None,
-        proxy: typing.Optional["HTTPXMock"] = None,
+        base_url: Optional[str] = None,
+        proxy: Optional["HTTPXMock"] = None,
     ) -> None:
         self._assert_all_called = assert_all_called
-        self._assert_all_mocked = assert_all_mocked
-        self._base_url = base_url
         self._proxy = proxy
-        self._mocks: typing.List[HTTPXMock] = []
-        self._patchers: typing.List[asynctest.mock._patch] = []
-        self._patterns: typing.List[RequestPattern] = []
-        self.aliases: typing.Dict[str, RequestPattern] = {}
-        self.stats = asynctest.mock.MagicMock()
-        self.calls: typing.List[typing.Tuple[Request, typing.Optional[Response]]] = []
+        super().__init__(assert_all_mocked=assert_all_mocked, base_url=base_url)
 
     def __call__(
         self,
-        func: typing.Optional[typing.Callable] = None,
-        assert_all_called: typing.Optional[bool] = None,
-        assert_all_mocked: typing.Optional[bool] = None,
-        base_url: typing.Optional[str] = None,
-    ) -> typing.Union["HTTPXMock", typing.Callable]:
+        func: Optional[Callable] = None,
+        assert_all_called: Optional[bool] = None,
+        assert_all_mocked: Optional[bool] = None,
+        base_url: Optional[str] = None,
+    ) -> Union["HTTPXMock", Callable]:
         """
         Decorator or Context Manager.
 
@@ -56,7 +52,7 @@ class HTTPXMock:
             # - Only stage when using local ctx `with respx.mock(...) as httpx_mock:`
             # - First stage when using local decorator `@respx.mock(...)`
             #   FYI, global ctx `with respx.mock:` hits __enter__ directly
-            settings: typing.Dict[str, typing.Any] = {
+            settings: Dict[str, Any] = {
                 "base_url": base_url,
                 "proxy": self,
             }
@@ -89,28 +85,29 @@ class HTTPXMock:
         # - Second stage when using local decorator `@respx.mock(...)`
         return async_decorator if inspect.iscoroutinefunction(func) else sync_decorator
 
-    def __enter__(self) -> "HTTPXMock":
+    def __enter__(self) -> "MockTransport":
         self.start()
         return self
 
-    def __exit__(self, *args: typing.Any) -> None:
+    def __exit__(self, *args: Any) -> None:
         self.stop()
 
-    async def __aenter__(self) -> "HTTPXMock":
+    async def __aenter__(self) -> "MockTransport":
         return self.__enter__()
 
-    async def __aexit__(self, *args: typing.Any) -> None:
+    async def __aexit__(self, *args: Any) -> None:
         self.__exit__(*args)
 
     def start(self) -> None:
         """
-        Register mock/patterns and starts patching HTTPX.
+        Register transport and start patching.
         """
-        self._register(self)
+        self.transports.append(self)
+        self._patch()
 
     def stop(self, clear: bool = True, reset: bool = True) -> None:
         """
-        Unregister mock/patterns and stop patching HTTPX, when no registered mocks left.
+        Unregister transport and stop patching, when no registered transports left.
         """
         try:
             if self._assert_all_called:
@@ -121,450 +118,82 @@ class HTTPXMock:
             if reset:
                 self.reset()
 
-            self._unregister(self)
+            # Unregister current transport
+            assert self in self.transports, "RESPX transport already stopped!"
+            self.transports.remove(self)
+            self._unpatch()
 
-    def _register(self, httpx_mock: "HTTPXMock") -> None:
-        # Ensure we patch HTTPX using proxy instance
-        if self._proxy:
-            self._proxy._register(httpx_mock)
+    @classmethod
+    def _patch(cls) -> None:
+        # Ensure we only patch once!
+        if cls._patches:
             return
 
-        # Register given mock instance / patterns
-        self._mocks.append(httpx_mock)
-        self._patch()
+        # Start patching target transports
+        for target in cls.targets:
+            patch = asynctest.mock.patch(
+                target, spec=True, create=True, new_callable=cls._mock,
+            )
+            patch.start()
+            cls._patches.append(patch)
 
-    def _unregister(self, httpx_mock: "HTTPXMock") -> None:
-        # Ensure we unpatch HTTPX using proxy instance
-        if self._proxy is not None:
-            self._proxy._unregister(httpx_mock)
-            return
-
-        # Unregister given mock instance / patterns
-        assert httpx_mock in self._mocks, "HTTPX mock already stopped!"
-        self._mocks.remove(httpx_mock)
-        self._unpatch()
-
-    def _patch(self) -> None:
-        # Ensure we only patch HTTPX once!
-        if self._patchers:
-            return
-
-        # Unbound -> bound spy version of Client.send
-        def unbound_sync_send(
-            client: Client, request: Request, **kwargs: typing.Any
-        ) -> Response:
-            return self.__Client__send__spy(client, request, **kwargs)
-
-        # Unbound -> bound spy version of AsyncClient.send
-        async def unbound_async_send(
-            client: AsyncClient, request: Request, **kwargs: typing.Any
-        ) -> Response:
-            return await self.__AsyncClient__send__spy(client, request, **kwargs)
-
-        # Start patching HTTPX
-        mockers = (
-            ("httpx.Client.send", unbound_sync_send),
-            ("httpx.AsyncClient.send", unbound_async_send),
-        )
-        for target, mocker in mockers:
-            patcher = asynctest.mock.patch(target, new=mocker)
-            patcher.start()
-            self._patchers.append(patcher)
-
-    def _unpatch(self) -> None:
-        # Ensure we don't stop patching HTTPX when registered mocks exists
-        if self._mocks:
+    @classmethod
+    def _unpatch(cls) -> None:
+        # Ensure we don't stop patching when registered transports exists
+        if cls.transports:
             return
 
         # Stop patching HTTPX
-        while self._patchers:
-            patcher = self._patchers.pop()
-            patcher.stop()
+        while cls._patches:
+            patch = cls._patches.pop()
+            patch.stop()
 
-    def clear(self) -> None:
-        """
-        Clears added patterns and aliases.
-        """
-        self._patterns.clear()
-        self.aliases.clear()
+    @classmethod
+    def _mock(cls, spec):
+        if inspect.iscoroutinefunction(spec):
 
-    def reset(self) -> None:
-        """
-        Resets call stats.
-        """
-        self.calls.clear()
-        self.stats.reset_mock()
-
-    def assert_all_called(self) -> None:
-        assert all(
-            (pattern.called for pattern in self._patterns)
-        ), "RESPX: some mocked requests were not called!"
-
-    def add(self, pattern: RequestPattern) -> None:
-        self._patterns.append(pattern)
-        if pattern.alias:
-            self.aliases[pattern.alias] = pattern
-
-    def request(
-        self,
-        method: typing.Union[str, typing.Callable],
-        url: typing.Optional[typing.Union[str, typing.Pattern]] = None,
-        status_code: typing.Optional[int] = None,
-        content: typing.Optional[ContentDataTypes] = None,
-        content_type: typing.Optional[str] = None,
-        headers: typing.Optional[HeaderTypes] = None,
-        pass_through: bool = False,
-        alias: typing.Optional[str] = None,
-    ) -> RequestPattern:
-        """
-        Adds a request pattern with given mocked response details.
-        """
-        headers = Headers(headers or {})
-        if content_type:
-            headers["Content-Type"] = content_type
-
-        response = ResponseTemplate(status_code, headers, content)
-        pattern = RequestPattern(
-            method,
-            url,
-            response,
-            pass_through=pass_through,
-            alias=alias,
-            base_url=self._base_url,
-        )
-
-        self.add(pattern)
-
-        return pattern
-
-    def get(
-        self,
-        url: typing.Optional[typing.Union[str, typing.Pattern]] = None,
-        status_code: typing.Optional[int] = None,
-        content: typing.Optional[ContentDataTypes] = None,
-        content_type: typing.Optional[str] = None,
-        headers: typing.Optional[HeaderTypes] = None,
-        pass_through: bool = False,
-        alias: typing.Optional[str] = None,
-    ) -> RequestPattern:
-        return self.request(
-            "GET",
-            url=url,
-            status_code=status_code,
-            content=content,
-            content_type=content_type,
-            headers=headers,
-            pass_through=pass_through,
-            alias=alias,
-        )
-
-    def post(
-        self,
-        url: typing.Optional[typing.Union[str, typing.Pattern]] = None,
-        status_code: typing.Optional[int] = None,
-        content: typing.Optional[ContentDataTypes] = None,
-        content_type: typing.Optional[str] = None,
-        headers: typing.Optional[HeaderTypes] = None,
-        pass_through: bool = False,
-        alias: typing.Optional[str] = None,
-    ) -> RequestPattern:
-        return self.request(
-            "POST",
-            url=url,
-            status_code=status_code,
-            content=content,
-            content_type=content_type,
-            headers=headers,
-            pass_through=pass_through,
-            alias=alias,
-        )
-
-    def put(
-        self,
-        url: typing.Optional[typing.Union[str, typing.Pattern]] = None,
-        status_code: typing.Optional[int] = None,
-        content: typing.Optional[ContentDataTypes] = None,
-        content_type: typing.Optional[str] = None,
-        headers: typing.Optional[HeaderTypes] = None,
-        pass_through: bool = False,
-        alias: typing.Optional[str] = None,
-    ) -> RequestPattern:
-        return self.request(
-            "PUT",
-            url=url,
-            status_code=status_code,
-            content=content,
-            content_type=content_type,
-            headers=headers,
-            pass_through=pass_through,
-            alias=alias,
-        )
-
-    def patch(
-        self,
-        url: typing.Optional[typing.Union[str, typing.Pattern]] = None,
-        status_code: typing.Optional[int] = None,
-        content: typing.Optional[ContentDataTypes] = None,
-        content_type: typing.Optional[str] = None,
-        headers: typing.Optional[HeaderTypes] = None,
-        pass_through: bool = False,
-        alias: typing.Optional[str] = None,
-    ) -> RequestPattern:
-        return self.request(
-            "PATCH",
-            url=url,
-            status_code=status_code,
-            content=content,
-            content_type=content_type,
-            headers=headers,
-            pass_through=pass_through,
-            alias=alias,
-        )
-
-    def delete(
-        self,
-        url: typing.Optional[typing.Union[str, typing.Pattern]] = None,
-        status_code: typing.Optional[int] = None,
-        content: typing.Optional[ContentDataTypes] = None,
-        content_type: typing.Optional[str] = None,
-        headers: typing.Optional[HeaderTypes] = None,
-        pass_through: bool = False,
-        alias: typing.Optional[str] = None,
-    ) -> RequestPattern:
-        return self.request(
-            "DELETE",
-            url=url,
-            status_code=status_code,
-            content=content,
-            content_type=content_type,
-            headers=headers,
-            pass_through=pass_through,
-            alias=alias,
-        )
-
-    def head(
-        self,
-        url: typing.Optional[typing.Union[str, typing.Pattern]] = None,
-        status_code: typing.Optional[int] = None,
-        content: typing.Optional[ContentDataTypes] = None,
-        content_type: typing.Optional[str] = None,
-        headers: typing.Optional[HeaderTypes] = None,
-        pass_through: bool = False,
-        alias: typing.Optional[str] = None,
-    ) -> RequestPattern:
-        return self.request(
-            "HEAD",
-            url=url,
-            status_code=status_code,
-            content=content,
-            content_type=content_type,
-            headers=headers,
-            pass_through=pass_through,
-            alias=alias,
-        )
-
-    def options(
-        self,
-        url: typing.Optional[typing.Union[str, typing.Pattern]] = None,
-        status_code: typing.Optional[int] = None,
-        content: typing.Optional[ContentDataTypes] = None,
-        content_type: typing.Optional[str] = None,
-        headers: typing.Optional[HeaderTypes] = None,
-        pass_through: bool = False,
-        alias: typing.Optional[str] = None,
-    ) -> RequestPattern:
-        return self.request(
-            "OPTIONS",
-            url=url,
-            status_code=status_code,
-            content=content,
-            content_type=content_type,
-            headers=headers,
-            pass_through=pass_through,
-            alias=alias,
-        )
-
-    def __getitem__(self, alias: str) -> typing.Optional[RequestPattern]:
-        return self.aliases.get(alias)
-
-    def _match(
-        self, request: Request
-    ) -> typing.Tuple[
-        "HTTPXMock", typing.Optional[RequestPattern], typing.Optional[ResponseTemplate]
-    ]:
-        used_mock = self
-        matched_pattern: typing.Optional[RequestPattern] = None
-        matched_pattern_index: typing.Optional[int] = None
-        response: typing.Optional[ResponseTemplate] = None
-
-        # Iterate all started mockers and their patterns
-        for httpx_mock in self._mocks:
-            patterns = httpx_mock._patterns
-
-            for i, pattern in enumerate(patterns):
-                match = pattern.match(request)
-                if not match:
-                    continue
-
-                if matched_pattern_index is not None:
-                    # Multiple matches found, drop and use the first one
-                    patterns.pop(matched_pattern_index)
-                    break
-
-                used_mock = httpx_mock
-                matched_pattern = pattern
-                matched_pattern_index = i
-
-                if isinstance(match, ResponseTemplate):
-                    # Mock response
-                    response = match
-                elif isinstance(match, Request):
-                    # Pass-through request
-                    response = None
+            async def request(self, *args, **kwargs):
+                kwargs["pass_through"] = partial(spec, self)
+                response = None
+                error = None
+                for transport in cls.transports:
+                    try:
+                        response = await transport._async_request(*args, **kwargs)
+                    except AssertionError as e:
+                        error = e.args[0]
+                        continue
+                    else:
+                        break
                 else:
-                    raise ValueError(
-                        (
-                            "Matched request pattern must return either a "
-                            'ResponseTemplate or a Request, got "{}"'
-                        ).format(type(match))
-                    )
+                    assert response, error
+                return response
 
-            if matched_pattern:
-                break
+        else:
 
-        if matched_pattern is None:
-            # Assert we always get a pattern match, if check is enabled
-            allows_unmocked = tuple(m for m in self._mocks if not m._assert_all_mocked)
-            assert allows_unmocked, f"RESPX: {request!r} not mocked!"
+            def request(self, *args, **kwargs):
+                kwargs["pass_through"] = partial(spec, self)
+                response = None
+                error = None
+                for transport in cls.transports:
+                    try:
+                        response = transport._sync_request(*args, **kwargs)
+                    except AssertionError as e:
+                        error = e.args[0]
+                        continue
+                    else:
+                        break
+                else:
+                    assert response, error
+                return response
 
-            # Relate default response to first mocker that allows unmocked requests
-            used_mock = allows_unmocked[0]
-            response = ResponseTemplate()
+        return request
 
-        return used_mock, matched_pattern, response
 
-    def _capture(
-        self,
-        request: Request,
-        response: typing.Optional[Response],
-        pattern: typing.Optional[RequestPattern] = None,
-    ) -> None:
-        """
-        Captures request and response calls for statistics.
-        """
-        if pattern:
-            pattern.stats(request, response)
-
-        self.stats(request, response)
-
-        # Copy stats due to unwanted use of property refs in the high-level api
-        self.calls[:] = (
-            (request, response) for (request, response), _ in self.stats.call_args_list
+class HTTPXMock(MockTransport):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn(
+            "HTTPXMock() is due to be deprecated. Use MockTransport() instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-
-    @contextmanager
-    def _patch_dispatcher(
-        self, dispatch: typing.Union[SyncDispatcher, AsyncDispatcher], request: Request
-    ) -> typing.Iterator[typing.Callable]:
-        patchers = []
-
-        # 1. Match request against added patterns
-        httpx_mock, pattern, response = self._match(request)
-
-        if response is not None:
-            # 2. Patch request url with response for later pickup in patched dispatcher
-            request.url = URLResponse(request.url, response)
-
-            backend = getattr(dispatch, "backend", None)
-            if isinstance(backend, ConcurrencyBackend):
-                # 3A. Concurrency dispatcher -> Patch backend streams
-                mockers: typing.List[typing.Tuple[typing.Any, str, typing.Callable]] = [
-                    (backend, "open_tcp_stream", self.__Backend__open_tcp_stream__mock),
-                    (backend, "open_uds_stream", self.__Backend__open_uds_stream__mock),
-                ]
-            elif isinstance(dispatch, SyncDispatcher):
-                # 3B. Synchronous dispatcher -> Patch send()
-                mockers = [(dispatch, "send", self.__SyncDispatcher__send__mock)]
-            else:
-                # 3C. Asyncronous dispatcher -> Patch send()
-                mockers = [(dispatch, "send", self.__AsyncDispatcher__send__mock)]
-
-            for obj, target, mocker in mockers:
-                patcher = asynctest.mock.patch.object(obj, target, mocker)
-                patcher.start()
-                patchers.append(patcher)
-
-        try:
-            yield partial(httpx_mock._capture, pattern=pattern)
-        finally:
-            # 4. Stop patching
-            for patcher in patchers:
-                patcher.stop()
-
-    def __Client__send__spy(
-        self, client: Client, request: Request, **kwargs: typing.Any
-    ) -> Response:
-        """
-        Spy for Client.send().
-
-        Patches request.url and attaches matched response template,
-        and mocks client dispatcher send method.
-        """
-        with self._patch_dispatcher(client.dispatch, request) as capture:
-            try:
-                response = None
-                response = _Client__send(client, request, **kwargs)
-                return response
-            finally:
-                capture(request, response)
-
-    async def __AsyncClient__send__spy(
-        self, client: AsyncClient, request: Request, **kwargs: typing.Any
-    ) -> Response:
-        """
-        Spy for AsyncClient.send().
-
-        Patches request.url and attaches matched response template,
-        and mocks client concurrency backend open stream methods.
-        """
-        with self._patch_dispatcher(client.dispatch, request) as capture:
-            try:
-                response = None
-                response = await _AsyncClient__send(client, request, **kwargs)
-                return response
-            finally:
-                capture(request, response)
-
-    def __SyncDispatcher__send__mock(
-        self, request: Request, **kwargs: typing.Any
-    ) -> Response:
-        hostname = request.url.host
-        response = getattr(hostname, "attachment", None)  # Pickup attached template
-        return response.build(request)
-
-    async def __AsyncDispatcher__send__mock(
-        self, request: Request, **kwargs: typing.Any
-    ) -> Response:
-        hostname = request.url.host
-        response = getattr(hostname, "attachment", None)  # Pickup attached template
-        return await response.abuild(request)
-
-    async def __Backend__open_tcp_stream__mock(
-        self,
-        hostname: str,
-        port: int,
-        ssl_context: typing.Optional[ssl.SSLContext],
-        timeout: Timeout,
-    ) -> BaseSocketStream:
-        response = getattr(hostname, "attachment", None)  # Pickup attached template
-        return await response.socket_stream
-
-    async def __Backend__open_uds_stream__mock(
-        self,
-        path: str,
-        hostname: typing.Optional[str],
-        ssl_context: typing.Optional[ssl.SSLContext],
-        timeout: Timeout,
-    ) -> BaseSocketStream:
-        response = getattr(hostname, "attachment", None)  # Pickup attached template
-        return await response.socket_stream
+        super().__init__(*args, **kwargs)

--- a/respx/mocks.py
+++ b/respx/mocks.py
@@ -30,9 +30,12 @@ class MockTransport(BaseMockTransport):
         base_url: Optional[str] = None,
         local: bool = False,
     ) -> None:
-        self._assert_all_called = assert_all_called
         self._local = local
-        super().__init__(assert_all_mocked=assert_all_mocked, base_url=base_url)
+        super().__init__(
+            assert_all_called=assert_all_called,
+            assert_all_mocked=assert_all_mocked,
+            base_url=base_url,
+        )
 
     def __call__(
         self,

--- a/respx/transports.py
+++ b/respx/transports.py
@@ -26,8 +26,12 @@ from .models import (
 
 class BaseMockTransport:
     def __init__(
-        self, assert_all_mocked: bool = True, base_url: Optional[str] = None,
+        self,
+        assert_all_called: bool = True,
+        assert_all_mocked: bool = True,
+        base_url: Optional[str] = None,
     ) -> None:
+        self._assert_all_called = assert_all_called
         self._assert_all_mocked = assert_all_mocked
         self._base_url = base_url
 
@@ -371,6 +375,13 @@ class BaseMockTransport:
             raise
         finally:
             self.record(request, response, pattern=pattern)
+
+    def close(self) -> None:
+        if self._assert_all_called:
+            self.assert_all_called()
+
+    async def aclose(self) -> None:
+        self.close()
 
 
 class SyncMockTransport(BaseMockTransport, SyncHTTPTransport):

--- a/respx/transports.py
+++ b/respx/transports.py
@@ -1,0 +1,397 @@
+import warnings
+from typing import Any, Callable, Coroutine, Dict, List, Optional, Pattern, Tuple, Union
+
+import asynctest
+from httpcore import (
+    AsyncByteStream,
+    AsyncHTTPTransport,
+    SyncByteStream,
+    SyncHTTPTransport,
+)
+
+from .models import (
+    URL,
+    ContentDataTypes,
+    Headers,
+    HeaderTypes,
+    Request,
+    RequestPattern,
+    Response,
+    ResponseTemplate,
+    TimeoutDict,
+    build_request,
+    build_response,
+)
+
+
+class BaseMockTransport:
+    def __init__(
+        self, assert_all_mocked: bool = True, base_url: Optional[str] = None,
+    ) -> None:
+        self._assert_all_mocked = assert_all_mocked
+        self._base_url = base_url
+
+        self.patterns: List[RequestPattern] = []
+        self.aliases: Dict[str, RequestPattern] = {}
+
+        self.stats = asynctest.mock.MagicMock()
+        self.calls: List[Tuple[Request, Optional[Response]]] = []
+
+    def clear(self):
+        """
+        Clear added patterns.
+        """
+        self.patterns.clear()
+        self.aliases.clear()
+
+    def reset(self) -> None:
+        """
+        Resets call stats.
+        """
+        self.calls.clear()
+        self.stats.reset_mock()
+        for pattern in self.patterns:
+            pattern.stats.reset_mock()
+
+    def __getitem__(self, alias: str) -> Optional[RequestPattern]:
+        return self.aliases.get(alias)
+
+    def add(
+        self,
+        method: Union[str, Callable, RequestPattern],
+        url: Optional[Union[str, Pattern]] = None,
+        status_code: Optional[int] = None,
+        content: Optional[ContentDataTypes] = None,
+        content_type: Optional[str] = None,
+        headers: Optional[HeaderTypes] = None,
+        pass_through: bool = False,
+        alias: Optional[str] = None,
+    ) -> RequestPattern:
+        """
+        Adds a request pattern with given mocked response details.
+        """
+        if isinstance(method, RequestPattern):
+            pattern = method
+
+        else:
+            response = ResponseTemplate(
+                status_code, headers, content, content_type=content_type
+            )
+            pattern = RequestPattern(
+                method,
+                url,
+                response,
+                pass_through=pass_through,
+                alias=alias,
+                base_url=self._base_url,
+            )
+
+        self.patterns.append(pattern)
+        if pattern.alias:
+            self.aliases[pattern.alias] = pattern
+
+        return pattern
+
+    def get(
+        self,
+        url: Optional[Union[str, Pattern]] = None,
+        status_code: Optional[int] = None,
+        content: Optional[ContentDataTypes] = None,
+        content_type: Optional[str] = None,
+        headers: Optional[HeaderTypes] = None,
+        pass_through: bool = False,
+        alias: Optional[str] = None,
+    ) -> RequestPattern:
+        return self.add(
+            "GET",
+            url=url,
+            status_code=status_code,
+            content=content,
+            content_type=content_type,
+            headers=headers,
+            pass_through=pass_through,
+            alias=alias,
+        )
+
+    def post(
+        self,
+        url: Optional[Union[str, Pattern]] = None,
+        status_code: Optional[int] = None,
+        content: Optional[ContentDataTypes] = None,
+        content_type: Optional[str] = None,
+        headers: Optional[HeaderTypes] = None,
+        pass_through: bool = False,
+        alias: Optional[str] = None,
+    ) -> RequestPattern:
+        return self.add(
+            "POST",
+            url=url,
+            status_code=status_code,
+            content=content,
+            content_type=content_type,
+            headers=headers,
+            pass_through=pass_through,
+            alias=alias,
+        )
+
+    def put(
+        self,
+        url: Optional[Union[str, Pattern]] = None,
+        status_code: Optional[int] = None,
+        content: Optional[ContentDataTypes] = None,
+        content_type: Optional[str] = None,
+        headers: Optional[HeaderTypes] = None,
+        pass_through: bool = False,
+        alias: Optional[str] = None,
+    ) -> RequestPattern:
+        return self.add(
+            "PUT",
+            url=url,
+            status_code=status_code,
+            content=content,
+            content_type=content_type,
+            headers=headers,
+            pass_through=pass_through,
+            alias=alias,
+        )
+
+    def patch(
+        self,
+        url: Optional[Union[str, Pattern]] = None,
+        status_code: Optional[int] = None,
+        content: Optional[ContentDataTypes] = None,
+        content_type: Optional[str] = None,
+        headers: Optional[HeaderTypes] = None,
+        pass_through: bool = False,
+        alias: Optional[str] = None,
+    ) -> RequestPattern:
+        return self.add(
+            "PATCH",
+            url=url,
+            status_code=status_code,
+            content=content,
+            content_type=content_type,
+            headers=headers,
+            pass_through=pass_through,
+            alias=alias,
+        )
+
+    def delete(
+        self,
+        url: Optional[Union[str, Pattern]] = None,
+        status_code: Optional[int] = None,
+        content: Optional[ContentDataTypes] = None,
+        content_type: Optional[str] = None,
+        headers: Optional[HeaderTypes] = None,
+        pass_through: bool = False,
+        alias: Optional[str] = None,
+    ) -> RequestPattern:
+        return self.add(
+            "DELETE",
+            url=url,
+            status_code=status_code,
+            content=content,
+            content_type=content_type,
+            headers=headers,
+            pass_through=pass_through,
+            alias=alias,
+        )
+
+    def head(
+        self,
+        url: Optional[Union[str, Pattern]] = None,
+        status_code: Optional[int] = None,
+        content: Optional[ContentDataTypes] = None,
+        content_type: Optional[str] = None,
+        headers: Optional[HeaderTypes] = None,
+        pass_through: bool = False,
+        alias: Optional[str] = None,
+    ) -> RequestPattern:
+        return self.add(
+            "HEAD",
+            url=url,
+            status_code=status_code,
+            content=content,
+            content_type=content_type,
+            headers=headers,
+            pass_through=pass_through,
+            alias=alias,
+        )
+
+    def options(
+        self,
+        url: Optional[Union[str, Pattern]] = None,
+        status_code: Optional[int] = None,
+        content: Optional[ContentDataTypes] = None,
+        content_type: Optional[str] = None,
+        headers: Optional[HeaderTypes] = None,
+        pass_through: bool = False,
+        alias: Optional[str] = None,
+    ) -> RequestPattern:
+        return self.add(
+            "OPTIONS",
+            url=url,
+            status_code=status_code,
+            content=content,
+            content_type=content_type,
+            headers=headers,
+            pass_through=pass_through,
+            alias=alias,
+        )
+
+    def request(self, *args: Any, **kwargs: Any) -> RequestPattern:
+        warnings.warn(
+            "respx.request() is due to be deprecated. Use respx.add() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.add(*args, **kwargs)
+
+    def record(
+        self,
+        request: Any,
+        response: Optional[Any],
+        pattern: Optional[RequestPattern] = None,
+    ) -> None:
+        request = build_request(request)
+        response = build_response(response, request=request)
+
+        if pattern:
+            pattern.stats(request, response)
+
+        self.stats(request, response)
+
+        # Copy stats due to unwanted use of property refs in the high-level api
+        self.calls[:] = (
+            (request, response) for (request, response), _ in self.stats.call_args_list
+        )
+
+    def assert_all_called(self) -> None:
+        assert all(
+            (pattern.called for pattern in self.patterns)
+        ), "RESPX: some mocked requests were not called!"
+
+    def match(
+        self,
+        method: bytes,
+        url: URL,
+        headers: Headers,
+        stream: Union[SyncByteStream, AsyncByteStream],
+    ) -> Tuple[Optional[RequestPattern], Request, Optional[ResponseTemplate]]:
+        request: Request = (method, url, headers, stream)
+
+        matched_pattern: Optional[RequestPattern] = None
+        matched_pattern_index: Optional[int] = None
+        response: Optional[ResponseTemplate] = None
+
+        for i, pattern in enumerate(self.patterns):
+            match = pattern.match(request)
+            if not match:
+                continue
+
+            if matched_pattern_index is not None:
+                # Multiple matches found, drop and use the first one
+                self.patterns.pop(matched_pattern_index)
+                break
+
+            matched_pattern = pattern
+            matched_pattern_index = i
+
+            if isinstance(match, ResponseTemplate):
+                # Mock response
+                response = match
+            elif match == request:
+                # Pass-through request
+                response = None
+            else:
+                raise ValueError(
+                    (
+                        "Matched request pattern must return either a "
+                        'ResponseTemplate or a Request, got "{}"'
+                    ).format(type(match))
+                )
+
+        if matched_pattern is None:
+            # Assert we always get a pattern match, if check is enabled
+            assert not self._assert_all_mocked, f"RESPX: {request[1]!r} not mocked!"
+
+            # Auto mock a successfull empty response
+            response = ResponseTemplate()
+
+        return matched_pattern, request, response
+
+    def _sync_request(
+        self,
+        method: bytes,
+        url: URL,
+        headers: Headers,
+        stream: SyncByteStream,
+        timeout: Optional[TimeoutDict] = None,
+        pass_through: Optional[Callable[..., Response]] = None,
+    ) -> Response:
+        pattern, request, response_template = self.match(method, url, headers, stream)
+
+        try:
+            if response_template is None:
+                # Pass-through request
+                if pass_through is None:
+                    raise ValueError("pass_through not supported with manual transport")
+                response = pass_through(method, url, headers, stream, timeout)
+            else:
+                response = response_template.raw
+            return response
+        except Exception:
+            response = None  # type: ignore
+            raise
+        finally:
+            self.record(request, response, pattern=pattern)
+
+    async def _async_request(
+        self,
+        method: bytes,
+        url: URL,
+        headers: Headers,
+        stream: AsyncByteStream,
+        timeout: Optional[TimeoutDict] = None,
+        pass_through: Optional[Callable[..., Coroutine[Any, Any, Response]]] = None,
+    ) -> Response:
+        pattern, request, response_template = self.match(method, url, headers, stream)
+
+        try:
+            if response_template is None:
+                # Pass-through request
+                if pass_through is None:
+                    raise ValueError("pass_through not supported with manual transport")
+                response = await pass_through(method, url, headers, stream, timeout)
+            else:
+                response = await response_template.araw
+            return response
+        except Exception:
+            response = None  # type: ignore
+            raise
+        finally:
+            self.record(request, response, pattern=pattern)
+
+
+class SyncMockTransport(BaseMockTransport, SyncHTTPTransport):
+    def request(  # type: ignore
+        self,
+        method: bytes,
+        url: URL,
+        headers: Headers,
+        stream: SyncByteStream,
+        timeout: Optional[TimeoutDict] = None,
+    ) -> Response:
+        return self._sync_request(method, url, headers, stream, timeout)
+
+
+class AsyncMockTransport(BaseMockTransport, AsyncHTTPTransport):
+    async def request(  # type: ignore
+        self,
+        method: bytes,
+        url: URL,
+        headers: Headers,
+        stream: AsyncByteStream,
+        timeout: Optional[TimeoutDict] = None,
+    ) -> Response:
+        return await self._async_request(method, url, headers, stream, timeout)

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     python_requires=">=3.6",
-    install_requires=["httpx>=0.12,<0.13", "asynctest"],
+    install_requires=["httpx>=0.13,<0.14", "asynctest"],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,22 +12,22 @@ async def client():
 
 
 @pytest.fixture
-async def httpx_mock():
-    async with respx.mock(base_url="https://httpx.mock") as httpx_mock:
-        httpx_mock.get("/", status_code=404, alias="index")
-        yield httpx_mock
+async def my_mock():
+    async with respx.mock(base_url="https://httpx.mock") as respx_mock:
+        respx_mock.get("/", status_code=404, alias="index")
+        yield respx_mock
 
 
 @pytest.fixture(scope="session")
 async def mocked_foo(event_loop):  # noqa: F811
-    async with respx.mock(base_url="https://foo.api") as httpx_mock:
-        httpx_mock.get("/", status_code=202, alias="index")
-        httpx_mock.get("/bar/", alias="bar")
-        yield httpx_mock
+    async with respx.mock(base_url="https://foo.api") as respx_mock:
+        respx_mock.get("/", status_code=202, alias="index")
+        respx_mock.get("/bar/", alias="bar")
+        yield respx_mock
 
 
 @pytest.fixture(scope="session")
 async def mocked_ham(event_loop):  # noqa: F811
-    async with respx.mock(base_url="https://ham.api") as httpx_mock:
-        httpx_mock.get("/", status_code=200, alias="index")
-        yield httpx_mock
+    async with respx.mock(base_url="https://ham.api") as respx_mock:
+        respx_mock.get("/", status_code=200, alias="index")
+        yield respx_mock

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,13 +1,15 @@
 import asyncio
 import re
+import socket
 
 import asynctest
 import httpx
 import pytest
-from httpx._exceptions import NetworkError
-from urllib3.exceptions import SSLError
+from httpcore import NetworkError
 
 import respx
+from respx import MockTransport
+from respx.models import RequestPattern
 
 
 @pytest.mark.asyncio
@@ -63,10 +65,17 @@ async def test_http_methods(client):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "url", [None, "", "https://foo.bar/baz/", re.compile(r"^https://foo.bar/\w+/$")]
+    "url",
+    [
+        None,
+        "",
+        "https://foo.bar/baz/",
+        re.compile(r"^https://foo.bar/\w+/$"),
+        (b"https", b"foo.bar", 443, b"/baz/"),
+    ],
 )
 async def test_url_match(client, url):
-    async with respx.HTTPXMock(assert_all_mocked=False) as httpx_mock:
+    async with MockTransport(assert_all_mocked=False) as httpx_mock:
         request = httpx_mock.get(url, content="baz")
         response = await client.get("https://foo.bar/baz/")
         assert request.called is True
@@ -76,14 +85,14 @@ async def test_url_match(client, url):
 
 @pytest.mark.asyncio
 async def test_invalid_url_pattern():
-    async with respx.HTTPXMock() as httpx_mock:
+    async with MockTransport() as httpx_mock:
         with pytest.raises(ValueError):
             httpx_mock.get(["invalid"])
 
 
 @pytest.mark.asyncio
 async def test_repeated_pattern(client):
-    async with respx.HTTPXMock() as httpx_mock:
+    async with MockTransport() as httpx_mock:
         url = "https://foo/bar/baz/"
         one = httpx_mock.post(url, status_code=201)
         two = httpx_mock.post(url, status_code=409)
@@ -109,7 +118,7 @@ async def test_repeated_pattern(client):
 
 @pytest.mark.asyncio
 async def test_status_code(client):
-    async with respx.HTTPXMock() as httpx_mock:
+    async with MockTransport() as httpx_mock:
         url = "https://foo.bar/"
         request = httpx_mock.get(url, status_code=404)
         response = await client.get(url)
@@ -136,7 +145,7 @@ async def test_status_code(client):
     ],
 )
 async def test_headers(client, headers, content_type, expected):
-    async with respx.HTTPXMock() as httpx_mock:
+    async with MockTransport() as httpx_mock:
         url = "https://foo.bar/"
         request = httpx_mock.get(url, content_type=content_type, headers=headers)
         response = await client.get(url)
@@ -149,7 +158,7 @@ async def test_headers(client, headers, content_type, expected):
     "content,expected", [(b"eldr\xc3\xa4v", "eldräv"), ("äpple", "äpple")]
 )
 async def test_text_content(client, content, expected):
-    async with respx.HTTPXMock() as httpx_mock:
+    async with MockTransport() as httpx_mock:
         url = "https://foo.bar/"
         content_type = "text/plain; charset=utf-8"  # TODO: Remove once respected
         request = httpx_mock.post(url, content=content, content_type=content_type)
@@ -175,7 +184,7 @@ async def test_text_content(client, content, expected):
     ],
 )
 async def test_json_content(client, content, headers, expected_headers):
-    async with respx.HTTPXMock() as httpx_mock:
+    async with MockTransport() as httpx_mock:
         url = "https://foo.bar/"
         request = httpx_mock.get(url, content=content, headers=headers)
 
@@ -193,7 +202,7 @@ async def test_json_content(client, content, headers, expected_headers):
 
 @pytest.mark.asyncio
 async def test_raising_content(client):
-    async with respx.HTTPXMock() as httpx_mock:
+    async with MockTransport() as httpx_mock:
         url = "https://foo.bar/"
         request = httpx_mock.get(url, content=httpx.ConnectTimeout())
         with pytest.raises(httpx.ConnectTimeout):
@@ -207,7 +216,7 @@ async def test_raising_content(client):
 
 @pytest.mark.asyncio
 async def test_callable_content(client):
-    async with respx.HTTPXMock() as httpx_mock:
+    async with MockTransport() as httpx_mock:
         url_pattern = re.compile(r"https://foo.bar/(?P<slug>\w+)/")
         content = lambda request, slug: f"hello {slug}"
         request = httpx_mock.get(url_pattern, content=content)
@@ -233,10 +242,8 @@ async def test_request_callback(client):
             response.context["name"] = "lundberg"
             return response
 
-    async with respx.HTTPXMock(assert_all_called=False) as httpx_mock:
-        request = httpx_mock.request(
-            callback, status_code=202, headers={"X-Ham": "spam"}
-        )
+    async with MockTransport(assert_all_called=False) as httpx_mock:
+        request = httpx_mock.add(callback, status_code=202, headers={"X-Ham": "spam"})
         response = await client.get("https://foo.bar/")
 
         assert request.called is True
@@ -248,7 +255,7 @@ async def test_request_callback(client):
         assert response.text == "hello lundberg"
 
         with pytest.raises(ValueError):
-            httpx_mock.request(lambda req, res: "invalid")
+            httpx_mock.add(lambda req, res: "invalid")
             await client.get("https://ham.spam/")
 
 
@@ -256,13 +263,14 @@ async def test_request_callback(client):
 @pytest.mark.parametrize(
     "parameters,expected",
     [
-        ({"method": "GET", "url": "https://example.org/", "pass_through": True}, True,),
+        ({"method": "GET", "url": "https://example.org/", "pass_through": True}, True),
         ({"method": lambda request, response: request}, None),
+        ({"method": RequestPattern("GET", "http://foo.bar/", pass_through=True)}, True),
     ],
 )
 async def test_pass_through(client, parameters, expected):
-    async with respx.HTTPXMock() as httpx_mock:
-        request = httpx_mock.request(**parameters)
+    async with MockTransport() as httpx_mock:
+        request = httpx_mock.add(**parameters)
 
         with asynctest.mock.patch(
             "asyncio.open_connection",
@@ -275,15 +283,16 @@ async def test_pass_through(client, parameters, expected):
         assert request.called is True
         assert request.pass_through is expected
 
-        httpx_mock.reset()
+    with MockTransport() as httpx_mock:
+        request = httpx_mock.add(**parameters)
 
         with asynctest.mock.patch(
-            "urllib3.PoolManager.urlopen", side_effect=SSLError("test request blocked"),
-        ) as urlopen:
+            "socket.socket.connect", side_effect=socket.error("test request blocked"),
+        ) as connect:
             with pytest.raises(NetworkError):
                 httpx.get("https://example.org/")
 
-        assert urlopen.called is True
+        assert connect.called is True
         assert request.called is True
         assert request.pass_through is expected
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -75,8 +75,8 @@ async def test_http_methods(client):
     ],
 )
 async def test_url_match(client, url):
-    async with MockTransport(assert_all_mocked=False) as httpx_mock:
-        request = httpx_mock.get(url, content="baz")
+    async with MockTransport(assert_all_mocked=False) as respx_mock:
+        request = respx_mock.get(url, content="baz")
         response = await client.get("https://foo.bar/baz/")
         assert request.called is True
         assert response.status_code == 200
@@ -85,17 +85,17 @@ async def test_url_match(client, url):
 
 @pytest.mark.asyncio
 async def test_invalid_url_pattern():
-    async with MockTransport() as httpx_mock:
+    async with MockTransport() as respx_mock:
         with pytest.raises(ValueError):
-            httpx_mock.get(["invalid"])
+            respx_mock.get(["invalid"])
 
 
 @pytest.mark.asyncio
 async def test_repeated_pattern(client):
-    async with MockTransport() as httpx_mock:
+    async with MockTransport() as respx_mock:
         url = "https://foo/bar/baz/"
-        one = httpx_mock.post(url, status_code=201)
-        two = httpx_mock.post(url, status_code=409)
+        one = respx_mock.post(url, status_code=201)
+        two = respx_mock.post(url, status_code=409)
         response1 = await client.post(url, json={})
         response2 = await client.post(url, json={})
         response3 = await client.post(url, json={})
@@ -103,7 +103,7 @@ async def test_repeated_pattern(client):
         assert response1.status_code == 201
         assert response2.status_code == 409
         assert response3.status_code == 409
-        assert httpx_mock.stats.call_count == 3
+        assert respx_mock.stats.call_count == 3
 
         assert one.called is True
         assert one.call_count == 1
@@ -118,9 +118,9 @@ async def test_repeated_pattern(client):
 
 @pytest.mark.asyncio
 async def test_status_code(client):
-    async with MockTransport() as httpx_mock:
+    async with MockTransport() as respx_mock:
         url = "https://foo.bar/"
-        request = httpx_mock.get(url, status_code=404)
+        request = respx_mock.get(url, status_code=404)
         response = await client.get(url)
 
     assert request.called is True
@@ -145,9 +145,9 @@ async def test_status_code(client):
     ],
 )
 async def test_headers(client, headers, content_type, expected):
-    async with MockTransport() as httpx_mock:
+    async with MockTransport() as respx_mock:
         url = "https://foo.bar/"
-        request = httpx_mock.get(url, content_type=content_type, headers=headers)
+        request = respx_mock.get(url, content_type=content_type, headers=headers)
         response = await client.get(url)
         assert request.called is True
         assert response.headers == httpx.Headers(expected)
@@ -158,10 +158,10 @@ async def test_headers(client, headers, content_type, expected):
     "content,expected", [(b"eldr\xc3\xa4v", "eldräv"), ("äpple", "äpple")]
 )
 async def test_text_content(client, content, expected):
-    async with MockTransport() as httpx_mock:
+    async with MockTransport() as respx_mock:
         url = "https://foo.bar/"
         content_type = "text/plain; charset=utf-8"  # TODO: Remove once respected
-        request = httpx_mock.post(url, content=content, content_type=content_type)
+        request = respx_mock.post(url, content=content, content_type=content_type)
         response = await client.post(url)
         assert request.called is True
         assert response.text == expected
@@ -184,16 +184,16 @@ async def test_text_content(client, content, expected):
     ],
 )
 async def test_json_content(client, content, headers, expected_headers):
-    async with MockTransport() as httpx_mock:
+    async with MockTransport() as respx_mock:
         url = "https://foo.bar/"
-        request = httpx_mock.get(url, content=content, headers=headers)
+        request = respx_mock.get(url, content=content, headers=headers)
 
         async_response = await client.get(url)
         assert request.called is True
         assert async_response.headers == httpx.Headers(expected_headers or headers)
         assert async_response.json() == content
 
-        httpx_mock.reset()
+        respx_mock.reset()
         sync_response = httpx.get(url)
         assert request.called is True
         assert sync_response.headers == httpx.Headers(expected_headers or headers)
@@ -202,9 +202,9 @@ async def test_json_content(client, content, headers, expected_headers):
 
 @pytest.mark.asyncio
 async def test_raising_content(client):
-    async with MockTransport() as httpx_mock:
+    async with MockTransport() as respx_mock:
         url = "https://foo.bar/"
-        request = httpx_mock.get(url, content=httpx.ConnectTimeout())
+        request = respx_mock.get(url, content=httpx.ConnectTimeout())
         with pytest.raises(httpx.ConnectTimeout):
             await client.get(url)
 
@@ -216,17 +216,17 @@ async def test_raising_content(client):
 
 @pytest.mark.asyncio
 async def test_callable_content(client):
-    async with MockTransport() as httpx_mock:
+    async with MockTransport() as respx_mock:
         url_pattern = re.compile(r"https://foo.bar/(?P<slug>\w+)/")
         content = lambda request, slug: f"hello {slug}"
-        request = httpx_mock.get(url_pattern, content=content)
+        request = respx_mock.get(url_pattern, content=content)
 
         async_response = await client.get("https://foo.bar/world/")
         assert request.called is True
         assert async_response.status_code == 200
         assert async_response.text == "hello world"
 
-        httpx_mock.reset()
+        respx_mock.reset()
         sync_response = httpx.get("https://foo.bar/world/")
         assert request.called is True
         assert sync_response.status_code == 200
@@ -242,8 +242,8 @@ async def test_request_callback(client):
             response.context["name"] = "lundberg"
             return response
 
-    async with MockTransport(assert_all_called=False) as httpx_mock:
-        request = httpx_mock.add(callback, status_code=202, headers={"X-Ham": "spam"})
+    async with MockTransport(assert_all_called=False) as respx_mock:
+        request = respx_mock.add(callback, status_code=202, headers={"X-Ham": "spam"})
         response = await client.get("https://foo.bar/")
 
         assert request.called is True
@@ -255,7 +255,7 @@ async def test_request_callback(client):
         assert response.text == "hello lundberg"
 
         with pytest.raises(ValueError):
-            httpx_mock.add(lambda req, res: "invalid")
+            respx_mock.add(lambda req, res: "invalid")
             await client.get("https://ham.spam/")
 
 
@@ -269,8 +269,8 @@ async def test_request_callback(client):
     ],
 )
 async def test_pass_through(client, parameters, expected):
-    async with MockTransport() as httpx_mock:
-        request = httpx_mock.add(**parameters)
+    async with MockTransport() as respx_mock:
+        request = respx_mock.add(**parameters)
 
         with asynctest.mock.patch(
             "asyncio.open_connection",
@@ -283,8 +283,8 @@ async def test_pass_through(client, parameters, expected):
         assert request.called is True
         assert request.pass_through is expected
 
-    with MockTransport() as httpx_mock:
-        request = httpx_mock.add(**parameters)
+    with MockTransport() as respx_mock:
+        request = respx_mock.add(**parameters)
 
         with asynctest.mock.patch(
             "socket.socket.connect", side_effect=socket.error("test request blocked"),

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -20,16 +20,16 @@ async def test_decorating_test(client):
 
 
 @pytest.mark.asyncio
-async def test_mock_request_fixture(client, httpx_mock):
+async def test_mock_request_fixture(client, my_mock):
     assert respx.stats.call_count == 0
-    assert httpx_mock.stats.call_count == 0
+    assert my_mock.stats.call_count == 0
     response = await client.get("https://httpx.mock/")
-    request = httpx_mock.aliases["index"]
+    request = my_mock.aliases["index"]
     assert request.called is True
     assert response.is_error
     assert response.status_code == 404
     assert respx.stats.call_count == 0
-    assert httpx_mock.stats.call_count == 1
+    assert my_mock.stats.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -94,14 +94,14 @@ async def test_global_async_decorator(client):
 
 def test_local_sync_decorator():
     @respx.mock()
-    def test(httpx_mock):
+    def test(respx_mock):
         assert respx.stats.call_count == 0
-        request = httpx_mock.get("https://foo.bar/", status_code=202)
+        request = respx_mock.get("https://foo.bar/", status_code=202)
         response = httpx.get("https://foo.bar/")
         assert request.called is True
         assert response.status_code == 202
         assert respx.stats.call_count == 0
-        assert httpx_mock.stats.call_count == 1
+        assert respx_mock.stats.call_count == 1
 
     assert respx.stats.call_count == 0
     test()
@@ -111,14 +111,14 @@ def test_local_sync_decorator():
 @pytest.mark.asyncio
 async def test_local_async_decorator(client):
     @respx.mock()
-    async def test(httpx_mock):
+    async def test(respx_mock):
         assert respx.stats.call_count == 0
-        request = httpx_mock.get("https://foo.bar/", status_code=202)
+        request = respx_mock.get("https://foo.bar/", status_code=202)
         response = await client.get("https://foo.bar/")
         assert request.called is True
         assert response.status_code == 202
         assert respx.stats.call_count == 0
-        assert httpx_mock.stats.call_count == 1
+        assert respx_mock.stats.call_count == 1
 
     await test()
     assert respx.stats.call_count == 0
@@ -147,48 +147,48 @@ async def test_global_contextmanager(client):
 
 @pytest.mark.asyncio
 async def test_local_contextmanager(client):
-    with respx.mock() as httpx_mock:
-        assert httpx_mock.stats.call_count == 0
-        request = httpx_mock.get("https://foo/bar/", status_code=202)
+    with respx.mock() as respx_mock:
+        assert respx_mock.stats.call_count == 0
+        request = respx_mock.get("https://foo/bar/", status_code=202)
         response = await client.get("https://foo/bar/")
         assert request.called is True
         assert response.status_code == 202
         assert respx.stats.call_count == 0
-        assert httpx_mock.stats.call_count == 1
+        assert respx_mock.stats.call_count == 1
 
-    async with respx.mock() as httpx_mock:
-        assert httpx_mock.stats.call_count == 0
-        request = httpx_mock.get("https://foo/bar/", status_code=202)
+    async with respx.mock() as respx_mock:
+        assert respx_mock.stats.call_count == 0
+        request = respx_mock.get("https://foo/bar/", status_code=202)
         response = await client.get("https://foo/bar/")
         assert request.called is True
         assert response.status_code == 202
         assert respx.stats.call_count == 0
-        assert httpx_mock.stats.call_count == 1
+        assert respx_mock.stats.call_count == 1
 
     assert respx.stats.call_count == 0
 
 
 @pytest.mark.asyncio
 async def test_nested_local_contextmanager(client):
-    with respx.mock() as httpx_mock_1:
-        get_request = httpx_mock_1.get("https://foo/bar/", status_code=202)
+    with respx.mock() as respx_mock_1:
+        get_request = respx_mock_1.get("https://foo/bar/", status_code=202)
 
-        with respx.mock() as httpx_mock_2:
-            post_request = httpx_mock_2.post("https://foo/bar/", status_code=201)
+        with respx.mock() as respx_mock_2:
+            post_request = respx_mock_2.post("https://foo/bar/", status_code=201)
 
             response = await client.get("https://foo/bar/")
             assert get_request.called is True
             assert response.status_code == 202
             assert respx.stats.call_count == 0
-            assert httpx_mock_1.stats.call_count == 1
-            assert httpx_mock_2.stats.call_count == 0
+            assert respx_mock_1.stats.call_count == 1
+            assert respx_mock_2.stats.call_count == 0
 
             response = await client.post("https://foo/bar/")
             assert post_request.called is True
             assert response.status_code == 201
             assert respx.stats.call_count == 0
-            assert httpx_mock_1.stats.call_count == 1
-            assert httpx_mock_2.stats.call_count == 1
+            assert respx_mock_1.stats.call_count == 1
+            assert respx_mock_2.stats.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -213,9 +213,9 @@ async def test_nested_global_contextmanager(client):
 @pytest.mark.asyncio
 async def test_configured_decorator(client):
     @respx.mock(assert_all_called=False, assert_all_mocked=False)
-    async def test(httpx_mock):
-        assert httpx_mock.stats.call_count == 0
-        request = httpx_mock.get("https://foo.bar/")
+    async def test(respx_mock):
+        assert respx_mock.stats.call_count == 0
+        request = respx_mock.get("https://foo.bar/")
         response = await client.get("https://some.thing/")
 
         assert response.status_code == 200
@@ -224,9 +224,9 @@ async def test_configured_decorator(client):
 
         assert request.called is False
         assert respx.stats.call_count == 0
-        assert httpx_mock.stats.call_count == 1
+        assert respx_mock.stats.call_count == 1
 
-        _request, _response = httpx_mock.calls[-1]
+        _request, _response = respx_mock.calls[-1]
         assert _request is not None
         assert _response is not None
         assert _request.url == "https://some.thing/"
@@ -236,11 +236,13 @@ async def test_configured_decorator(client):
 
 
 @pytest.mark.asyncio
-async def test_base_url():
-    async with respx.mock(base_url="https://foo.bar/") as httpx_mock:
-        request1 = httpx_mock.get("/baz/", content="baz")
-        request2 = httpx_mock.post(re.compile(r"(?P<slug>\w+)/?$"), content="slug")
-        request3 = httpx_mock.put(content="ok")
+@respx.mock(base_url="https://ham.spam/")
+async def test_base_url(respx_mock=None):
+    request = respx_mock.patch("/egg/", content="yolk")
+    async with respx.mock(base_url="https://foo.bar/") as foobar_mock:
+        request1 = foobar_mock.get("/baz/", content="baz")
+        request2 = foobar_mock.post(re.compile(r"(?P<slug>\w+)/?$"), content="slug")
+        request3 = foobar_mock.put(content="ok")
 
         async with httpx.AsyncClient(base_url="https://foo.bar") as client:
             response = await client.get("/baz/")
@@ -254,6 +256,10 @@ async def test_base_url():
             response = await client.put("/")
             assert request3.called is True
             assert response.text == "ok"
+
+            response = await client.patch("https://ham.spam/egg/")
+            assert request.called is True
+            assert response.text == "yolk"
 
 
 @pytest.mark.asyncio
@@ -300,9 +306,9 @@ async def test_start_stop(client):
 )
 async def test_assert_all_called(client, assert_all_called, do_post, raises):
     with raises:
-        async with MockTransport(assert_all_called=assert_all_called) as httpx_mock:
-            request1 = httpx_mock.get("https://foo.bar/1/", status_code=404)
-            request2 = httpx_mock.post("https://foo.bar/", status_code=201)
+        async with MockTransport(assert_all_called=assert_all_called) as respx_mock:
+            request1 = respx_mock.get("https://foo.bar/1/", status_code=404)
+            request2 = respx_mock.post("https://foo.bar/", status_code=201)
 
             await client.get("https://foo.bar/1/")
             if do_post:
@@ -319,16 +325,16 @@ async def test_assert_all_called(client, assert_all_called, do_post, raises):
 )
 async def test_assert_all_mocked(client, assert_all_mocked, raises):
     with raises:
-        with MockTransport(assert_all_mocked=assert_all_mocked) as httpx_mock:
+        with MockTransport(assert_all_mocked=assert_all_mocked) as respx_mock:
             response = httpx.get("https://foo.bar/")
-            assert httpx_mock.stats.call_count == 1
+            assert respx_mock.stats.call_count == 1
             assert response.status_code == 200
     with raises:
-        async with MockTransport(assert_all_mocked=assert_all_mocked) as httpx_mock:
+        async with MockTransport(assert_all_mocked=assert_all_mocked) as respx_mock:
             response = await client.get("https://foo.bar/")
-            assert httpx_mock.stats.call_count == 1
+            assert respx_mock.stats.call_count == 1
             assert response.status_code == 200
-    assert httpx_mock.stats.call_count == 0
+    assert respx_mock.stats.call_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -14,31 +14,31 @@ from respx import MockTransport
 
 @pytest.mark.asyncio
 async def test_alias():
-    async with MockTransport(assert_all_called=False) as httpx_mock:
+    async with MockTransport(assert_all_called=False) as respx_mock:
         url = "https://foo.bar/"
-        request = httpx_mock.get(url, alias="foobar")
+        request = respx_mock.get(url, alias="foobar")
         assert "foobar" not in respx.aliases
-        assert "foobar" in httpx_mock.aliases
-        assert httpx_mock.aliases["foobar"].url == request.url
-        assert httpx_mock["foobar"].url == request.url
+        assert "foobar" in respx_mock.aliases
+        assert respx_mock.aliases["foobar"].url == request.url
+        assert respx_mock["foobar"].url == request.url
 
 
 @pytest.mark.xfail(strict=True)
 @pytest.mark.asyncio
 async def test_httpx_exception_handling(client):  # pragma: no cover
-    async with MockTransport() as httpx_mock:
+    async with MockTransport() as respx_mock:
         with asynctest.mock.patch(
             "httpx._client.AsyncClient.dispatcher_for_url",
             side_effect=ValueError("mock"),
         ):
             url = "https://foo.bar/"
-            request = httpx_mock.get(url)
+            request = respx_mock.get(url)
             with pytest.raises(ValueError):
                 await client.get(url)
 
         assert request.called is True
-        assert httpx_mock.stats.call_count == 1
-        _request, _response = httpx_mock.calls[-1]
+        assert respx_mock.stats.call_count == 1
+        _request, _response = respx_mock.calls[-1]
         assert _request is not None
         assert _response is None
 

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -7,10 +7,11 @@ from respx import AsyncMockTransport, SyncMockTransport
 def test_sync_transport():
     url = "https://foo.bar/"
 
-    transport = SyncMockTransport()
+    transport = SyncMockTransport(assert_all_called=False)
     transport.get(url, status_code=404)
     transport.get(url, content={"foo": "bar"})
     transport.post(url, pass_through=True)
+    transport.put(url)
 
     with httpx.Client(transport=transport) as client:
         response = client.get(url)
@@ -26,10 +27,11 @@ def test_sync_transport():
 async def test_async_transport():
     url = "https://foo.bar/"
 
-    transport = AsyncMockTransport()
+    transport = AsyncMockTransport(assert_all_called=False)
     transport.get(url, status_code=404)
     transport.get(url, content={"foo": "bar"})
     transport.post(url, pass_through=True)
+    transport.put(url)
 
     async with httpx.AsyncClient(transport=transport) as client:
         response = await client.get(url)
@@ -39,3 +41,17 @@ async def test_async_transport():
         assert response.json() == {"foo": "bar"}
         with pytest.raises(ValueError, match="pass_through"):
             await client.post(url)
+
+
+@pytest.mark.asyncio
+async def test_transport_assertions():
+    url = "https://foo.bar/"
+
+    transport = AsyncMockTransport()
+    transport.get(url, status_code=404)
+    transport.post(url, content={"foo": "bar"})
+
+    with pytest.raises(AssertionError, match="not called"):
+        async with httpx.AsyncClient(transport=transport) as client:
+            response = await client.get(url)
+            assert response.status_code == 404

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -1,0 +1,41 @@
+import httpx
+import pytest
+
+from respx import AsyncMockTransport, SyncMockTransport
+
+
+def test_sync_transport():
+    url = "https://foo.bar/"
+
+    transport = SyncMockTransport()
+    transport.get(url, status_code=404)
+    transport.get(url, content={"foo": "bar"})
+    transport.post(url, pass_through=True)
+
+    with httpx.Client(transport=transport) as client:
+        response = client.get(url)
+        assert response.status_code == 404
+        response = client.get(url)
+        assert response.status_code == 200
+        assert response.json() == {"foo": "bar"}
+        with pytest.raises(ValueError, match="pass_through"):
+            client.post(url)
+
+
+@pytest.mark.asyncio
+async def test_async_transport():
+    url = "https://foo.bar/"
+
+    transport = AsyncMockTransport()
+    transport.get(url, status_code=404)
+    transport.get(url, content={"foo": "bar"})
+    transport.post(url, pass_through=True)
+
+    async with httpx.AsyncClient(transport=transport) as client:
+        response = await client.get(url)
+        assert response.status_code == 404
+        response = await client.get(url)
+        assert response.status_code == 200
+        assert response.json() == {"foo": "bar"}
+        with pytest.raises(ValueError, match="pass_through"):
+            await client.post(url)


### PR DESCRIPTION
During the last couple of HTTPX releases, a lot of things has happend.

HTTPX dispatchers and backends has been refactored into a `transport` API, along with the release of `httpcore`.

This **PR** involves a lot of refactoring, but mainly turning the `HTTPXMock` into a `transport`, without changing too much, if any, of the RESPX API.

A result of this is both adding support for HTTPX v0.13+, but also allowing mocking of requests/responses for other libraries, than HTTPX, that depends on `httpcore`.

