### PR TITLE
Add method to pop a request pattern by alias

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -175,6 +175,33 @@ def test_something():
     assert response.json() == {"id": 123}
 ```
 
+### Manipulating Existing Patterns
+
+Clearing all existing patterns:
+
+``` python
+import respx
+
+
+@respx.mock
+def test_something():
+    respx.get("https://foo.bar/baz", status_code=404)
+    respx.clear()  # no patterns will be matched after this call
+```
+
+Removing and optionally re-using an existing pattern by alias:
+
+``` python
+import respx
+
+
+@respx.mock
+def test_something():
+    respx.get("https://foo.bar/", status_code=404, alias="index")
+    request_pattern = respx.pop("index")
+    respx.get(request_pattern.url, status_code=200)
+```
+
 ---
 
 ## Response Content

--- a/respx/transports.py
+++ b/respx/transports.py
@@ -1,5 +1,17 @@
 import warnings
-from typing import Any, Callable, Coroutine, Dict, List, Optional, Pattern, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    Pattern,
+    Tuple,
+    TypeVar,
+    Union,
+    overload,
+)
 
 import asynctest
 from httpcore import (
@@ -22,6 +34,8 @@ from .models import (
     build_request,
     build_response,
 )
+
+DefaultType = TypeVar("DefaultType", bound=Any)
 
 
 class BaseMockTransport:
@@ -59,6 +73,31 @@ class BaseMockTransport:
 
     def __getitem__(self, alias: str) -> Optional[RequestPattern]:
         return self.aliases.get(alias)
+
+    @overload
+    def pop(self, alias: str) -> RequestPattern:
+        ...
+
+    @overload
+    def pop(
+        self, alias: str, default: DefaultType
+    ) -> Union[RequestPattern, DefaultType]:
+        ...
+
+    def pop(self, alias, default=...):
+        """
+        Removes a pattern by alias and returns it.
+
+        Raises KeyError when `default` not provided and alias is not found.
+        """
+        try:
+            request_pattern = self.aliases.pop(alias)
+            self.patterns.remove(request_pattern)
+            return request_pattern
+        except KeyError as ex:
+            if default is ...:
+                raise ex
+            return default
 
     def add(
         self,

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -85,3 +85,26 @@ async def test_httpcore_request():
             body = b"".join([chunk async for chunk in stream])
             await stream.aclose()
             assert body == b"foobar"
+
+
+@pytest.mark.asyncio
+async def test_transport_pop():
+    url = "https://foo.bar/"
+    alias = "get_alias"
+
+    transport = AsyncMockTransport()
+    transport.get(url, status_code=404, alias=alias)
+
+    request_pattern = transport.pop(alias)
+
+    assert request_pattern.response.status_code == 404
+    assert request_pattern.alias == alias
+    assert request_pattern.url == url
+
+    assert not transport.aliases
+    assert not transport.patterns
+
+    with pytest.raises(KeyError):
+        transport.pop(alias)
+
+    assert transport.pop(alias, "custom default") == "custom default"


### PR DESCRIPTION
Motivation for this feature is having a common set of mocked call for multiple tests and having an option to update only sub-set of them. Currently, I do the content of the `pop` function manually in code. The updated documentation shows the actual use case.

I chose `pop` to be in line with the apparent `Dict[alias, RequestPattern]` interface of `BaseMockTransport`.

Closes #62 