### PR TITLE
Drop asynctest dependency

### DIFF
--- a/respx/mocks.py
+++ b/respx/mocks.py
@@ -2,8 +2,7 @@ import inspect
 import warnings
 from functools import partial, wraps
 from typing import Any, Callable, Dict, List, Optional, Union
-
-import asynctest
+from unittest import mock
 
 from .transports import BaseMockTransport
 
@@ -11,7 +10,7 @@ __all__ = ["MockTransport", "HTTPXMock"]
 
 
 class MockTransport(BaseMockTransport):
-    _patches: List[asynctest.mock._patch] = []
+    _patches: List[mock._patch] = []
     transports: List["MockTransport"] = []
     targets = [
         "httpcore._sync.connection.SyncHTTPConnection.request",
@@ -136,9 +135,7 @@ class MockTransport(BaseMockTransport):
 
         # Start patching target transports
         for target in cls.targets:
-            patch = asynctest.mock.patch(
-                target, spec=True, create=True, new_callable=cls._mock,
-            )
+            patch = mock.patch(target, spec=True, create=True, new_callable=cls._mock)
             patch.start()
             cls._patches.append(patch)
 

--- a/respx/models.py
+++ b/respx/models.py
@@ -15,9 +15,9 @@ from typing import (
     Tuple,
     Union,
 )
+from unittest import mock
 from urllib.parse import urljoin, urlparse
 
-import asynctest
 import httpx  # TODO: Drop usage
 from httpcore import AsyncByteStream, SyncByteStream
 from httpx import Headers as HTTPXHeaders  # TODO: Drop usage
@@ -232,7 +232,7 @@ class RequestPattern:
 
         self.response = response or ResponseTemplate()
         self.alias = alias
-        self.stats = asynctest.mock.MagicMock()
+        self.stats = mock.MagicMock()
 
     @property
     def called(self):

--- a/respx/transports.py
+++ b/respx/transports.py
@@ -12,8 +12,8 @@ from typing import (
     Union,
     overload,
 )
+from unittest import mock
 
-import asynctest
 from httpcore import (
     AsyncByteStream,
     AsyncHTTPTransport,
@@ -52,7 +52,7 @@ class BaseMockTransport:
         self.patterns: List[RequestPattern] = []
         self.aliases: Dict[str, RequestPattern] = {}
 
-        self.stats = asynctest.mock.MagicMock()
+        self.stats = mock.MagicMock()
         self.calls: List[Tuple[Request, Optional[Response]]] = []
 
     def clear(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,3 @@ warn_unreachable = True
 
 [mypy-pytest.*]
 ignore_missing_imports = True
-
-[mypy-asynctest.*]
-ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     python_requires=">=3.6",
-    install_requires=["httpx>=0.14,<0.15", "asynctest"],
+    install_requires=["httpx>=0.14,<0.15"],
 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,8 @@
 import asyncio
 import re
 import socket
+from unittest import mock
 
-import asynctest
 import httpx
 import pytest
 
@@ -272,7 +272,7 @@ async def test_pass_through(client, parameters, expected):
     async with MockTransport() as respx_mock:
         request = respx_mock.add(**parameters)
 
-        with asynctest.mock.patch(
+        with mock.patch(
             "asyncio.open_connection",
             side_effect=ConnectionRefusedError("test request blocked"),
         ) as open_connection:
@@ -286,7 +286,7 @@ async def test_pass_through(client, parameters, expected):
     with MockTransport() as respx_mock:
         request = respx_mock.add(**parameters)
 
-        with asynctest.mock.patch(
+        with mock.patch(
             "socket.socket.connect", side_effect=socket.error("test request blocked"),
         ) as connect:
             with pytest.raises(httpx.NetworkError):

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -358,13 +358,15 @@ async def test_asgi():
 async def test_proxies():
     with respx.mock:
         respx.get("https://foo.bar/", content={"foo": "bar"})
-        with httpx.Client(proxies={"https": "https://1.1.1.1:1"}) as client:
+        with httpx.Client(proxies={"https://": "https://1.1.1.1:1"}) as client:
             response = client.get("https://foo.bar/")
         assert response.json() == {"foo": "bar"}
 
     async with respx.mock:
         respx.get("https://foo.bar/", content={"foo": "bar"})
-        async with httpx.AsyncClient(proxies={"https": "https://1.1.1.1:1"}) as client:
+        async with httpx.AsyncClient(
+            proxies={"https://": "https://1.1.1.1:1"}
+        ) as client:
             response = await client.get("https://foo.bar/")
         assert response.json() == {"foo": "bar"}
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,7 +1,7 @@
 import asyncio
 import re
+from unittest import mock
 
-import asynctest
 import httpx
 import pytest
 import trio
@@ -27,7 +27,7 @@ async def test_alias():
 @pytest.mark.asyncio
 async def test_httpx_exception_handling(client):  # pragma: no cover
     async with MockTransport() as respx_mock:
-        with asynctest.mock.patch(
+        with mock.patch(
             "httpx._client.AsyncClient.dispatcher_for_url",
             side_effect=ValueError("mock"),
         ):


### PR DESCRIPTION
Looks like we not need to depend on `asynctest` any more, due to the refactoring in #57 .

This PR replaces `asynctest` patching with builtin `unittest` for all supported versions.

Fixes #61 