### PR TITLE
Refactor encode/decode raw response

### DIFF
--- a/respx/api.py
+++ b/respx/api.py
@@ -32,12 +32,12 @@ def reset() -> None:
 
 @overload
 def pop(alias: str) -> RequestPattern:
-    ...
+    ...  # pragma: nocover
 
 
 @overload
 def pop(alias: str, default: DefaultType) -> Union[RequestPattern, DefaultType]:
-    ...
+    ...  # pragma: nocover
 
 
 def pop(alias, default=...):

--- a/respx/models.py
+++ b/respx/models.py
@@ -1,13 +1,12 @@
 import inspect
-import json as jsonlib
 import re
 from functools import partial
 from typing import (
     Any,
-    AsyncIterator,
+    AsyncIterable,
     Callable,
     Dict,
-    Iterator,
+    Iterable,
     List,
     Optional,
     Pattern,
@@ -19,9 +18,8 @@ from typing import (
 from unittest import mock
 from urllib.parse import urljoin, urlparse
 
-import httpx  # TODO: Drop usage
+import httpx
 from httpcore import AsyncByteStream, SyncByteStream
-from httpx import Headers as HTTPXHeaders  # TODO: Drop usage
 
 URL = Tuple[bytes, bytes, Optional[int], bytes]
 Headers = List[Tuple[bytes, bytes]]
@@ -29,7 +27,7 @@ Request = Tuple[
     bytes,  # http method
     URL,
     Headers,
-    Union[SyncByteStream, AsyncByteStream],
+    Union[Iterable[bytes], AsyncIterable[bytes]],  # body
 ]
 SyncResponse = Tuple[
     int,  # status code
@@ -43,10 +41,15 @@ AsyncResponse = Tuple[
     AsyncByteStream,  # body
     dict,  # ext
 ]
-Response = Union[SyncResponse, AsyncResponse]
+Response = Tuple[
+    int,  # status code
+    Headers,
+    Union[Iterable[bytes], AsyncIterable[bytes]],  # body
+    dict,  # ext
+]
 
 HeaderTypes = Union[
-    HTTPXHeaders,
+    httpx.Headers,
     Dict[str, str],
     Dict[bytes, bytes],
     Sequence[Tuple[str, str]],
@@ -58,154 +61,200 @@ DefaultType = TypeVar("DefaultType", bound=Any)
 Regex = type(re.compile(""))
 Kwargs = Dict[str, Any]
 URLPatternTypes = Union[str, Pattern[str], URL]
-ContentDataTypes = Union[bytes, str, List, Dict, Callable, Exception]
+JSONTypes = Union[str, List, Dict]
+ContentDataTypes = Union[bytes, str, JSONTypes, Callable, Exception]
 
 istype = lambda t, o: isinstance(o, t)
 isregex = partial(istype, Regex)
 
 
-def build_request(request: Request) -> Union[httpx.Request, Request]:
+def decode_request(request: Request) -> httpx.Request:
     """
-    Try to re-build a httpx request from httpcore request args
+    Build a httpx Request from httpcore request args.
     """
-    try:
-        from httpx import Request as _Request
-    except ImportError:  # pragma: no cover
-        return request
-    else:
-        method, url, headers, stream = request
-        return _Request(method, url, headers=headers, stream=stream)
+    method, url, headers, stream = request
+    return httpx.Request(method, url, headers=headers, stream=stream)
 
 
-def build_response(
-    response: Optional[Response], request: Union[httpx.Request, Request]
-) -> Optional[Union[httpx.Response, Response]]:
+def decode_response(
+    response: Optional[Response], request: httpx.Request
+) -> Optional[httpx.Response]:
     """
-    Try to re-build a httpx response from httpcore response
+    Build a httpx Response from httpcore response args.
     """
     if response is None:
         return None
-    if not isinstance(request, httpx.Request):  # pragma: no cover
-        return response
-    try:
-        from httpx import Response as _Response
-    except ImportError:  # pragma: no cover
-        return response
-    else:
-        status_code, headers, stream, ext = response
-        httpx_response = _Response(
-            status_code,
-            headers=headers,
-            stream=stream,
-            ext=ext,
-            request=request,
-        )
 
-        # Pre-read response stream, but only if mocked, not pass-through
-        if isinstance(stream, ContentStream):
-            httpx_response.read()
-
-        return httpx_response
-
-
-class ContentStream(AsyncByteStream, SyncByteStream):
-    def __init__(self, content: bytes) -> None:
-        self._content = content
-        self.close_func = None
-        self.aclose_func = None
-
-    def __iter__(self) -> Iterator[bytes]:
-        yield self._content
-
-    async def __aiter__(self) -> AsyncIterator[bytes]:
-        yield self._content
+    status_code, headers, stream, ext = response
+    return httpx.Response(
+        status_code, headers=headers, stream=stream, ext=ext, request=request
+    )
 
 
 class ResponseTemplate:
+    _content: Optional[ContentDataTypes]
+    _text: Optional[str]
+    _html: Optional[str]
+    _json: Optional[JSONTypes]
+
     def __init__(
         self,
         status_code: Optional[int] = None,
-        headers: Optional[HeaderTypes] = None,
+        *,
         content: Optional[ContentDataTypes] = None,
+        text: Optional[str] = None,
+        html: Optional[str] = None,
+        json: Optional[JSONTypes] = None,
+        headers: Optional[HeaderTypes] = None,
         content_type: Optional[str] = None,
+        http_version: Optional[str] = None,
         context: Optional[Kwargs] = None,
     ) -> None:
-        self.http_version = 1.1
+        self.http_version = http_version
         self.status_code = status_code or 200
         self.context = context if context is not None else {}
-        self._content = content if content is not None else b""
-        self._headers = HTTPXHeaders(headers) if headers else HTTPXHeaders()
+
+        self.headers = httpx.Headers(headers) if headers else httpx.Headers()
         if content_type:
-            self._headers["Content-Type"] = content_type
+            self.headers["Content-Type"] = content_type
+
+        # Set body variants in reverse priority order
+        self.json = json
+        self.html = html
+        self.text = text
+        self.content = content
 
     def clone(self, context: Optional[Kwargs] = None) -> "ResponseTemplate":
         return ResponseTemplate(
-            self.status_code, self._headers, self._content, context=context
+            self.status_code,
+            content=self.content,
+            text=self.text,
+            html=self.html,
+            json=self.json,
+            headers=self.headers,
+            http_version=self.http_version,
+            context=context,
+        )
+
+    def prepare(
+        self,
+        content: Optional[ContentDataTypes],
+        *,
+        text: Optional[str] = None,
+        html: Optional[str] = None,
+        json: Optional[JSONTypes] = None,
+    ) -> Tuple[
+        Optional[ContentDataTypes], Optional[str], Optional[str], Optional[JSONTypes]
+    ]:
+        if content is not None:
+            text = None
+            html = None
+            json = None
+            if isinstance(content, str):
+                text = content
+                content = None
+            elif isinstance(content, (list, dict)):
+                json = content
+                content = None
+        elif text is not None:
+            html = None
+            json = None
+        elif html is not None:
+            json = None
+
+        return content, text, html, json
+
+    @property
+    def content(self) -> Optional[ContentDataTypes]:
+        return self._content
+
+    @content.setter
+    def content(self, content: Optional[ContentDataTypes]) -> None:
+        self._content, self.text, self.html, self.json = self.prepare(
+            content, text=self.text, html=self.html, json=self.json
         )
 
     @property
-    def headers(self) -> HTTPXHeaders:
-        if "Content-Type" not in self._headers:
-            self._headers["Content-Type"] = "text/plain"
-        return self._headers
+    def text(self) -> Optional[str]:
+        return self._text
+
+    @text.setter
+    def text(self, text: Optional[str]) -> None:
+        self._text = text
+        if text is not None:
+            self._content = None
+            self._html = None
+            self._json = None
 
     @property
-    def content(self) -> bytes:
-        return self.encode_content(self._content)
+    def html(self) -> Optional[str]:
+        return self._html
 
-    @content.setter
-    def content(self, content: ContentDataTypes) -> None:
-        self._content = content
+    @html.setter
+    def html(self, html: Optional[str]) -> None:
+        self._html = html
+        if html is not None:
+            self._content = None
+            self._text = None
+            self._json = None
 
     @property
-    async def acontent(self) -> bytes:
-        content: ContentDataTypes = self._content
+    def json(self) -> Optional[JSONTypes]:
+        return self._json
 
-        # Pre-handle async content callbacks
-        if callable(content) and inspect.iscoroutinefunction(content):
-            content = await content(**self.context)
+    @json.setter
+    def json(self, json: Optional[JSONTypes]) -> None:
+        self._json = json
+        if json is not None:
+            self._content = None
+            self._text = None
+            self._html = None
 
-        return self.encode_content(content)
-
-    def encode_content(self, content: ContentDataTypes) -> bytes:
-        if callable(content):
-            content = content(**self.context)
-
+    def encode_response(self, content: ContentDataTypes) -> Response:
         if isinstance(content, Exception):
             raise content
 
-        if isinstance(content, bytes):
-            return content
+        content, text, html, json = self.prepare(
+            content, text=self.text, html=self.html, json=self.json
+        )
 
-        if isinstance(content, (list, dict)):
-            content = jsonlib.dumps(content)
-            if "Content-Type" not in self._headers:
-                self._headers["Content-Type"] = "application/json"
+        # Comply with httpx Response content type hints
+        assert content is None or isinstance(content, bytes)
 
-        assert isinstance(content, str), "Invalid type of content"
-        content = content.encode("utf-8")  # TODO: Respect charset
+        response = httpx.Response(
+            self.status_code,
+            headers=self.headers,
+            content=content,
+            text=text,
+            html=html,
+            json=json,
+        )
 
-        return content
+        if self.http_version:
+            response.ext["http_version"] = self.http_version
+
+        return (
+            response.status_code,
+            response.headers.raw,
+            response.stream,
+            response.ext,
+        )
 
     @property
     def raw(self):
-        stream = ContentStream(self.content)
-        return (
-            self.status_code,
-            self.headers.raw,
-            stream,
-            {"http_version": f"HTTP/{self.http_version}".encode("ascii")},
-        )
+        content = self._content
+        if callable(content):
+            content = content(**self.context)
+
+        return self.encode_response(content)
 
     @property
     async def araw(self):
-        stream = ContentStream(await self.acontent)
-        return (
-            self.status_code,
-            self.headers.raw,
-            stream,
-            {"http_version": f"HTTP/{self.http_version}".encode("ascii")},
-        )
+        if callable(self._content) and inspect.iscoroutinefunction(self._content):
+            content = await self._content(**self.context)
+            return self.encode_response(content)
+
+        return self.raw
 
 
 class RequestPattern:
@@ -295,7 +344,7 @@ class RequestPattern:
         """
         matches = False
         url_params: Kwargs = {}
-        _request = build_request(request)
+        _request = decode_request(request)
 
         if self.pass_through:
             return request

--- a/respx/transports.py
+++ b/respx/transports.py
@@ -63,13 +63,13 @@ class BaseMockTransport:
 
     @overload
     def pop(self, alias: str) -> RequestPattern:
-        ...
+        ...  # pragma: nocover
 
     @overload
     def pop(
         self, alias: str, default: DefaultType
     ) -> Union[RequestPattern, DefaultType]:
-        ...
+        ...  # pragma: nocover
 
     def pop(self, alias, default=...):
         """

--- a/respx/transports.py
+++ b/respx/transports.py
@@ -20,8 +20,8 @@ from .models import (
     Response,
     ResponseTemplate,
     SyncResponse,
-    build_request,
-    build_response,
+    decode_request,
+    decode_response,
 )
 
 
@@ -105,7 +105,7 @@ class BaseMockTransport:
 
         else:
             response = ResponseTemplate(
-                status_code, headers, content, content_type=content_type
+                status_code, headers=headers, content=content, content_type=content_type
             )
             pattern = RequestPattern(
                 method,
@@ -275,8 +275,16 @@ class BaseMockTransport:
         response: Optional[Any],
         pattern: Optional[RequestPattern] = None,
     ) -> None:
-        request = build_request(request)
-        response = build_response(response, request=request)
+        # Decode raw request/response as HTTPX models
+        request = decode_request(request)
+        response = decode_response(response, request=request)
+
+        # TODO: Skip recording stats for pass_through requests?
+        # Pre-read response, but only if mocked, not pass-through streams streams
+        if response and not isinstance(
+            response.stream, (SyncByteStream, AsyncByteStream)
+        ):
+            response.read()
 
         if pattern:
             pattern.stats(request, response)

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -219,7 +219,7 @@ async def test_configured_decorator(client):
         response = await client.get("https://some.thing/")
 
         assert response.status_code == 200
-        assert response.headers == httpx.Headers({"Content-Type": "text/plain"})
+        assert response.headers == httpx.Headers()
         assert response.text == ""
 
         assert request.called is False
@@ -349,7 +349,7 @@ async def test_asgi():
             assert request.called is True
             assert response.status_code == 202
             assert response.headers == httpx.Headers(
-                {"Content-Type": "application/json", **headers}
+                {"Content-Type": "application/json", "Content-Length": "16", **headers}
             )
             assert response.json() == {"status": "ok"}
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -74,9 +74,8 @@ def test_stats(Backend):
         assert isinstance(_response, httpx.Response)
         assert _request.method == "GET"
         assert _request.url == url
-        assert _response.status_code == 202
-        assert _response.status_code == get_response.status_code
-        assert _response.content == get_response.content
+        assert _response.status_code == get_response.status_code == 202
+        assert _response.content == get_response.content == b"get"
         assert id(_response) != id(get_response)  # TODO: Fix this?
 
         _request, _response = foobar2.calls[-1]
@@ -84,9 +83,8 @@ def test_stats(Backend):
         assert isinstance(_response, httpx.Response)
         assert _request.method == "DELETE"
         assert _request.url == url
-        assert _response.status_code == 200
-        assert _response.status_code == del_response.status_code
-        assert _response.content == del_response.content
+        assert _response.status_code == del_response.status_code == 200
+        assert _response.content == del_response.content == b"del"
         assert id(_response) != id(del_response)  # TODO: Fix this?
 
         assert respx.stats.call_count == 2

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,6 +1,5 @@
 import asyncio
 import re
-from unittest import mock
 
 import httpx
 import pytest
@@ -21,26 +20,6 @@ async def test_alias():
         assert "foobar" in respx_mock.aliases
         assert respx_mock.aliases["foobar"].url == request.url
         assert respx_mock["foobar"].url == request.url
-
-
-@pytest.mark.xfail(strict=True)
-@pytest.mark.asyncio
-async def test_httpx_exception_handling(client):  # pragma: no cover
-    async with MockTransport() as respx_mock:
-        with mock.patch(
-            "httpx._client.AsyncClient.dispatcher_for_url",
-            side_effect=ValueError("mock"),
-        ):
-            url = "https://foo.bar/"
-            request = respx_mock.get(url)
-            with pytest.raises(ValueError):
-                await client.get(url)
-
-        assert request.called is True
-        assert respx_mock.stats.call_count == 1
-        _request, _response = respx_mock.calls[-1]
-        assert _request is not None
-        assert _response is None
 
 
 @pytest.mark.parametrize("Backend", [AsyncioBackend, TrioBackend])

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -68,7 +68,6 @@ async def test_httpcore_request():
             )
 
             body = b"".join([chunk for chunk in stream])
-            stream.close()
             assert body == b"foobar"
 
         async with httpcore.AsyncConnectionPool() as http:
@@ -77,7 +76,6 @@ async def test_httpcore_request():
             )
 
             body = b"".join([chunk async for chunk in stream])
-            await stream.aclose()
             assert body == b"foobar"
 
 


### PR DESCRIPTION
Refactors encoding and decoding of raw responses by using `httpx.Response`.

Enables support for creating response templates with `content`, `text`, `html` and `json` body variants.

Public api and `MockTransport` can easily be extended with these *"body"* args in a separate PR, but probably after #81 which restricting `kwargs` in api methods.