### PR TITLE
Refactor call stats with easier api

### DIFF
--- a/respx/api.py
+++ b/respx/api.py
@@ -1,13 +1,13 @@
 from typing import Callable, Optional, Pattern, Union, overload
 
 from .mocks import MockTransport
-from .models import ContentDataTypes, DefaultType, HeaderTypes, RequestPattern
+from .models import CallList, ContentDataTypes, DefaultType, HeaderTypes, RequestPattern
 
 mock = MockTransport(assert_all_called=False)
 
 aliases = mock.aliases
 stats = mock.stats
-calls = mock.calls
+calls: CallList = mock.calls
 
 
 def start() -> None:

--- a/respx/models.py
+++ b/respx/models.py
@@ -130,7 +130,7 @@ class CallList(list):
 
     @property
     def last(self) -> Optional[Call]:
-        return self[-1] if len(self) else None
+        return self[-1] if self else None
 
 
 class ContentStream(AsyncByteStream, SyncByteStream):

--- a/respx/models.py
+++ b/respx/models.py
@@ -8,7 +8,6 @@ from typing import (
     Callable,
     Dict,
     Generator,
-    Iterator,
     Iterable,
     List,
     NamedTuple,

--- a/respx/models.py
+++ b/respx/models.py
@@ -235,18 +235,26 @@ class RequestPattern:
         self.stats = mock.MagicMock()
 
     @property
-    def called(self):
+    def called(self) -> bool:
         return self.stats.called
 
     @property
-    def call_count(self):
+    def call_count(self) -> int:
         return self.stats.call_count
 
     @property
-    def calls(self):
+    def calls(self) -> List[Tuple[Request, ResponseTemplate]]:
         return [
             (request, response) for (request, response), _ in self.stats.call_args_list
         ]
+
+    @property
+    def last_request(self) -> Optional[Request]:
+        calls = self.calls
+        if not calls:
+            return None
+
+        return calls[-1][0]
 
     def get_url(self) -> Optional[URLPatternTypes]:
         return self._url

--- a/respx/models.py
+++ b/respx/models.py
@@ -130,10 +130,7 @@ class CallList(list):
 
     @property
     def last(self) -> Optional[Call]:
-        if self:
-            return self[-1]
-
-        return None
+        return self[-1] if len(self) else None
 
 
 class ContentStream(AsyncByteStream, SyncByteStream):

--- a/respx/models.py
+++ b/respx/models.py
@@ -1,7 +1,6 @@
 import inspect
 import json as jsonlib
 import re
-from collections import namedtuple
 from functools import partial
 from typing import (
     TYPE_CHECKING,

--- a/respx/models.py
+++ b/respx/models.py
@@ -25,7 +25,7 @@ import httpx
 from httpcore import AsyncByteStream, SyncByteStream
 
 if TYPE_CHECKING:
-    from unittest.mock import _CallList
+    from unittest.mock import _CallList  # pragma: nocover
 
 
 URL = Tuple[bytes, bytes, Optional[int], bytes]

--- a/respx/transports.py
+++ b/respx/transports.py
@@ -1,7 +1,6 @@
 from typing import Any, Callable, Dict, List, Optional, Pattern, Tuple, Union, overload
 from unittest import mock
 
-import httpx
 from httpcore import (
     AsyncByteStream,
     AsyncHTTPTransport,
@@ -19,7 +18,6 @@ from .models import (
     HeaderTypes,
     Request,
     RequestPattern,
-    Response,
     ResponseTemplate,
     SyncResponse,
     build_request,

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -226,9 +226,11 @@ async def test_configured_decorator(client):
         assert respx.stats.call_count == 0
         assert respx_mock.stats.call_count == 1
 
-        _request, _response = respx_mock.calls[-1]
+        _request, _response = respx_mock.calls.last
         assert _request is not None
         assert _response is not None
+        assert respx_mock.calls.last.request is _request
+        assert respx_mock.calls.last.response is _response
         assert _request.url == "https://some.thing/"
 
     await test()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -57,6 +57,7 @@ def test_stats(Backend):
         assert foobar1.called is False
         assert foobar1.call_count == len(foobar1.calls)
         assert foobar1.call_count == 0
+        assert foobar1.last_request is None
         assert respx.stats.call_count == len(respx.calls)
         assert respx.stats.call_count == 0
 
@@ -72,6 +73,7 @@ def test_stats(Backend):
         _request, _response = foobar1.calls[-1]
         assert isinstance(_request, httpx.Request)
         assert isinstance(_response, httpx.Response)
+        assert foobar1.last_request is _request
         assert _request.method == "GET"
         assert _request.url == url
         assert _response.status_code == 202

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -57,7 +57,7 @@ def test_stats(Backend):
         assert foobar1.called is False
         assert foobar1.call_count == len(foobar1.calls)
         assert foobar1.call_count == 0
-        assert foobar1.last_request is None
+        assert foobar1.calls.last is None
         assert respx.stats.call_count == len(respx.calls)
         assert respx.stats.call_count == 0
 
@@ -73,7 +73,8 @@ def test_stats(Backend):
         _request, _response = foobar1.calls[-1]
         assert isinstance(_request, httpx.Request)
         assert isinstance(_response, httpx.Response)
-        assert foobar1.last_request is _request
+        assert foobar1.calls.last.request is _request
+        assert foobar1.calls.last.response is _response
         assert _request.method == "GET"
         assert _request.url == url
         assert _response.status_code == 202
@@ -107,8 +108,8 @@ def test_stats(Backend):
     if isinstance(backend, TrioBackend):
         trio.run(test, backend)
     else:
+        loop = asyncio.new_event_loop()
         try:
-            loop = asyncio.new_event_loop()
             loop.run_until_complete(test(backend))
         finally:
             loop.close()


### PR DESCRIPTION
Inspired by [requests_mock last_request](https://requests-mock.readthedocs.io/en/latest/history.html?highlight=last_request#request-objects) property. I found it very convenient 