### PR TITLE
Pre-read recorded requests

### DIFF
--- a/respx/transports.py
+++ b/respx/transports.py
@@ -280,10 +280,11 @@ class BaseMockTransport:
         response = decode_response(response, request=request)
 
         # TODO: Skip recording stats for pass_through requests?
-        # Pre-read response, but only if mocked, not pass-through streams streams
+        # Pre-read request/response, but only if mocked, not for pass-through streams
         if response and not isinstance(
             response.stream, (SyncByteStream, AsyncByteStream)
         ):
+            request.read()
             response.read()
 
         if pattern:


### PR DESCRIPTION
This PR pre-reads a *"recorded"* httpx `Request` in call stats, like already done with `Response`, to simplify inspection and assertion of a request call's content.

Fixes #83 