### PR TITLE
Add support for using route as side effect decorator

### DIFF
--- a/respx/models.py
+++ b/respx/models.py
@@ -264,6 +264,10 @@ class Route:
             return hash(self._side_effect)
         return id(self)
 
+    def __call__(self, side_effect: Callable) -> Callable:
+        self.side_effect(side_effect)
+        return side_effect
+
     def __mod__(
         self, response: Union[int, Dict[str, Any], MockResponse, httpx.Response]
     ) -> "Route":

--- a/respx/models.py
+++ b/respx/models.py
@@ -376,7 +376,7 @@ class Route:
             else:
                 # Callable
                 argspec = inspect.getfullargspec(self._side_effect)
-                if "response" in argspec.args or len(argspec.args) > 1:
+                if "response" in argspec.args or len(argspec.args) > 1 + len(kwargs):
                     warn(
                         "Side effect (callback) `response` arg is deprecated. "
                         "Please instantiate httpx.Response inside your function.",

--- a/respx/patterns.py
+++ b/respx/patterns.py
@@ -24,8 +24,9 @@ class Lookup(Enum):
     EXACT = "exact"
     REGEX = "regex"
     STARTS_WITH = "startswith"
-    # TODO: Add more lookups
-    # NOT_EQUAL = "ne"
+    # TODO: Add more lookups and use Pattern.lookups[0] as default
+    # CONTAINS = "contains"
+    # IN = "in"
     # RANGE = "range"
 
 

--- a/respx/router.py
+++ b/respx/router.py
@@ -128,7 +128,7 @@ class Router:
         """
         Adds a route with given mocked response details.
         """
-        if callable(route):
+        if callable(route) and not isinstance(route, Route):
             route = Route().side_effect(route)
 
         elif isinstance(route, str):


### PR DESCRIPTION
Allows a route to be used as decorator to set side effect.

```py
@respx.get("https://foo.bar/baz/")
def baz(request):
    return httpx.Response(200)

@respx.route(method="GET", path__regex=r"/(?P<slug>\w+)/")
def baz(request, slug):
    return httpx.Response(200, text=slug)
```