### PR TITLE
Refactor side effects

### DIFF
--- a/respx/models.py
+++ b/respx/models.py
@@ -264,6 +264,9 @@ class Route:
             return hash(self._side_effect)
         return id(self)
 
+    def __repr__(self):
+        return f"<Route {self.pattern!r}>"  # pragma: no cover
+
     def __call__(self, side_effect: Callable) -> Callable:
         self.side_effect(side_effect)
         return side_effect

--- a/respx/models.py
+++ b/respx/models.py
@@ -1,16 +1,5 @@
 import inspect
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    NamedTuple,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Dict, NamedTuple, Optional, Tuple, Type, Union, cast
 from unittest import mock
 from warnings import warn
 
@@ -26,6 +15,7 @@ from .types import (
     QueryParamTypes,
     RequestTypes,
     Response,
+    SideEffectTypes,
     URLPatternTypes,
 )
 
@@ -50,6 +40,21 @@ def encode_response(response: httpx.Response) -> Response:
         response.stream,
         response.ext,
     )
+
+
+def clone_response(response: httpx.Response, request: httpx.Request) -> httpx.Response:
+    """
+    Clones a httpx Response for given request.
+    """
+    response = httpx.Response(
+        response.status_code,
+        headers=response.headers,
+        stream=response.stream,
+        request=request,
+        ext=dict(response.ext),
+    )
+    response.read()
+    return response
 
 
 class Call(NamedTuple):
@@ -112,6 +117,8 @@ class MockResponse:
         self.content = content
 
     def clone(self, **context: Any) -> "MockResponse":
+        merged_context = dict(self.context)
+        merged_context.update(context)
         return MockResponse(
             self.status_code,
             content=self.content,
@@ -120,7 +127,7 @@ class MockResponse:
             json=self.json,
             headers=self.headers,
             http_version=self.http_version,
-            context=context,
+            context=merged_context,
         )
 
     def prepare(
@@ -197,15 +204,15 @@ class MockResponse:
             self._text = None
             self._html = None
 
-    def as_response(self, request: Optional[httpx.Request]) -> httpx.Response:
+    def as_response(self) -> httpx.Response:
         content = self._content
+        context = dict(self.context)
+        request = decode_request(context.pop("request"))
 
         if callable(content):
             if inspect.iscoroutinefunction(self._content):
                 raise NotImplementedError("Async content callback no longer supported.")
-            kwargs = dict(self.context)
-            request = decode_request(kwargs.pop("request"))
-            content = content(request, **kwargs)
+            content = content(request, **context)
 
         if isinstance(content, Exception):
             raise content
@@ -224,7 +231,7 @@ class MockResponse:
             text=text,
             html=html,
             json=json,
-            request=decode_request(self.context.get("request")),
+            request=request,
         )
 
         if self.http_version:
@@ -251,35 +258,71 @@ class Route:
         self.pattern = M(*patterns, **lookups)
         self.name: Optional[str] = None  # TODO: Drop or add setter to prevent change
         self.calls = CallList()
-        self._responses: List[Union[MockResponse, httpx.Response]] = []
-        self._side_effect: Optional[Union[Callable, Exception, Type[Exception]]] = None
+        self._return_value: Union[MockResponse, httpx.Response] = None
+        self._side_effect: Optional[SideEffectTypes] = None
         self._pass_through: Optional[bool] = None
 
     def __hash__(self):
         if self.pattern:
             return hash(self.pattern)
-        elif self._pass_through is not None:
-            return hash(self._pass_through)
-        elif self._side_effect:
-            return hash(self._side_effect)
         return id(self)
 
     def __repr__(self):
         return f"<Route {self.pattern!r}>"  # pragma: no cover
 
     def __call__(self, side_effect: Callable) -> Callable:
-        self.side_effect(side_effect)
+        self.side_effect = side_effect
         return side_effect
 
-    def __mod__(
-        self, response: Union[int, Dict[str, Any], MockResponse, httpx.Response]
-    ) -> "Route":
+    def __mod__(self, response: Union[int, Dict[str, Any]]) -> "Route":
         if isinstance(response, int):
-            response = httpx.Response(response)
-        if isinstance(response, dict):
+            self.return_value = httpx.Response(status_code=response)
+
+        elif isinstance(response, dict):
             response.setdefault("status_code", 200)
-            response = httpx.Response(**response)
-        return self.add_response(response)
+            self.return_value = httpx.Response(**response)
+
+        else:
+            assert isinstance(
+                response, (httpx.Response, MockResponse)
+            ), f"Route can only % with int or dict, got {response!r}"
+            self.return_value = response
+
+        return self
+
+    @property
+    def return_value(self) -> Optional[Union[MockResponse, httpx.Response]]:
+        return self._return_value
+
+    @return_value.setter
+    def return_value(
+        self, return_value: Optional[Union[MockResponse, httpx.Response]]
+    ) -> None:
+        self.pass_through(None)
+        self._return_value = return_value
+
+    @property
+    def side_effect(self) -> Optional[SideEffectTypes]:
+        return self._side_effect
+
+    @side_effect.setter
+    def side_effect(self, side_effect: Optional[SideEffectTypes]) -> None:
+        self.pass_through(None)
+        if not side_effect:
+            side_effect = None
+        elif isinstance(side_effect, (list, tuple)):
+            side_effect = list(side_effect)
+        self._side_effect = side_effect
+
+    def mock(
+        self,
+        return_value: Optional[Union[MockResponse, httpx.Response]] = None,
+        *,
+        side_effect: Optional[SideEffectTypes] = None,
+    ) -> "Route":
+        self.return_value = return_value
+        self.side_effect = side_effect
+        return self
 
     def respond(
         self,
@@ -303,35 +346,11 @@ class Route:
             stream=stream,
             **kwargs,
         )
-        return self.add_response(response)
-
-    def add_response(self, response: Union[MockResponse, httpx.Response]) -> "Route":
-        self._responses.append(response)
-        return self
-
-    def side_effect(
-        self, side_effect: Union[Callable, Exception, List[httpx.Response]]
-    ) -> "Route":
-        self.pass_through(None)
-        if isinstance(side_effect, list):
-            self._responses[:] = side_effect
-            self._side_effect = None
-        elif isinstance(side_effect, Exception):
-            self._side_effect = side_effect
-        else:
-            self._side_effect = side_effect
-        return self
+        return self.mock(return_value=response)
 
     def pass_through(self, value: bool = True) -> "Route":
         self._pass_through = value
-        if value is not None:
-            self._side_effect = None
-            self._responses.clear()
         return self
-
-    @property
-    def has_side_effect(self) -> bool:
-        return bool(self._side_effect)
 
     @property
     def is_pass_through(self) -> bool:
@@ -361,92 +380,114 @@ class Route:
         )
         return self.calls
 
+    def _next_side_effect(
+        self,
+    ) -> Union[Callable, Exception, Type[Exception], httpx.Response]:
+        effect: Union[Callable, Exception, Type[Exception], httpx.Response]
+        if isinstance(self._side_effect, list):
+            # TODO: Use iter() as python's Mock and reach StopIteration error?
+            if len(self._side_effect) > 1:
+                effect = self._side_effect.pop(0)  # Stacked effects, pop in added order
+            else:
+                effect = self._side_effect[0]  # Single repeated effect
+        else:
+            effect = self._side_effect
+
+        return effect
+
+    def _call_side_effect(
+        self, effect: Callable, request: httpx.Request, **kwargs: Any
+    ) -> Optional[Union[httpx.Request, httpx.Response, MockResponse]]:
+        argspec = inspect.getfullargspec(effect)
+        if "response" in argspec.args or len(argspec.args) > 1 + len(kwargs):
+            warn(
+                "Side effect (callback) `response` arg is deprecated. "
+                "Please instantiate httpx.Response inside your function.",
+                category=DeprecationWarning,
+            )
+            args = (
+                request,
+                MockResponse(context={"request": request, **kwargs}),
+            )
+        else:
+            args = (request,)  # type: ignore
+
+        # Call side effect
+        try:
+            result = effect(*args, **kwargs)
+        except Exception as error:
+            raise SideEffectError(self, origin=error) from error
+
+        # Validate result
+        if result and not isinstance(
+            result, (httpx.Response, MockResponse, httpx.Request)
+        ):
+            raise ValueError(
+                f"Side effects must return; either `httpx.Response` or "
+                f"`MockResponse`, `httpx.Request` for pass-through, "
+                f"or `None` for a non-match. Got {result!r}"
+            )
+
+        return result
+
+    def _resolve_side_effect(
+        self, request: httpx.Request, **kwargs: Any
+    ) -> Optional[Union[httpx.Request, httpx.Response, MockResponse]]:
+        effect = self._next_side_effect()
+
+        # Handle Exception `instance` side effect
+        if isinstance(effect, Exception):
+            raise SideEffectError(self, origin=effect)
+
+        # Handle Exception `type` side effect
+        Error: Type[Exception] = cast(Type[Exception], effect)
+        if isinstance(effect, type) and issubclass(Error, Exception):
+            raise SideEffectError(
+                self,
+                origin=(
+                    Error("Mock Error", request=request)
+                    if issubclass(Error, httpx.HTTPError)
+                    else Error()
+                ),
+            )
+
+        # Handle `Callable` side effect
+        if callable(effect):
+            result = self._call_side_effect(effect, request, **kwargs)
+            return result
+
+        return effect
+
     def resolve(
         self, request: httpx.Request, **kwargs: Any
     ) -> Optional[Union[httpx.Request, httpx.Response]]:
-        response: Optional[Union[MockResponse, httpx.Response, httpx.Request]] = None
+        result: Optional[Union[MockResponse, httpx.Response, httpx.Request]] = None
 
         if self._side_effect:
-            Error: Type[Exception] = cast(Type[Exception], self._side_effect)
+            result = self._resolve_side_effect(request, **kwargs)
+            if result is None:
+                return None  # Side effect resolved as a non-matching route
 
-            if isinstance(self._side_effect, Exception):
-                # Eception instance
-                raise self._side_effect
+        elif self._return_value:
+            result = self._return_value
 
-            elif isinstance(self._side_effect, type) and issubclass(Error, Exception):
-                # Exception type
-                if issubclass(Error, httpx.HTTPError):
-                    raise Error("Mock Error", request=request)
-                else:
-                    raise Error()
-
-            else:
-                # Callable
-                argspec = inspect.getfullargspec(self._side_effect)
-                if "response" in argspec.args or len(argspec.args) > 1 + len(kwargs):
-                    warn(
-                        "Side effect (callback) `response` arg is deprecated. "
-                        "Please instantiate httpx.Response inside your function.",
-                        category=DeprecationWarning,
-                    )
-                    args = (
-                        request,
-                        MockResponse(context=kwargs),
-                    )
-                else:
-                    args = (request,)  # type: ignore
-
-                try:
-                    # Call side effect
-                    response = self._side_effect(*args, **kwargs)
-                except Exception as error:
-                    raise SideEffectError(self, origin=error) from error
-
-                if response and not isinstance(
-                    response, (httpx.Response, MockResponse, httpx.Request)
-                ):
-                    raise ValueError(
-                        f"Side effects must return; either `httpx.Response` or "
-                        f"`MockResponse`, `httpx.Request` for pass-through, "
-                        f"or `None` for a non-match. Got {response!r}"
-                    )
-
-                if response is None:
-                    # Side effect resolved as a non-matching route
-                    return None
-
-        elif len(self._responses) == 1:
-            # Single repeated response
-            response = self._responses[0]
-
-        elif len(self._responses) > 1:
-            # Stacked response, pop in added order
-            response = self._responses.pop(0)
-
-        if isinstance(response, MockResponse):
-            # Resolve MockResponse as httpx.Response
+        if isinstance(result, MockResponse):
+            # Resolve MockResponse into httpx.Response
             try:
-                mock_response = response.clone(request=request, **kwargs)
-                response = mock_response.as_response(request)
+                result = result.clone(request=request, **kwargs)
+                result = result.as_response()
             except Exception as error:
                 raise SideEffectError(self, origin=error) from error
 
-        if response is None:
-            # Create new response
-            response = httpx.Response(200, request=request)
+        if result is None:
+            # Auto mock a new response
+            result = httpx.Response(200, request=request)
 
-        elif isinstance(response, httpx.Response) and not response._request:
-            # Clone existing response for immutability
-            response = httpx.Response(
-                response.status_code,
-                headers=response.headers,
-                stream=response.stream,
-                request=request,
-                ext=dict(response.ext),
-            )
-            response.read()
+        elif isinstance(result, httpx.Response) and not result._request:
+            # Clone existing Response for immutability
+            result = clone_response(result, request)
 
-        return response
+        return result
 
     def match(
         self, request: httpx.Request
@@ -459,9 +500,6 @@ class Route:
         """
         context = {}
 
-        if not self.pattern and not self._side_effect and self._pass_through is None:
-            return None
-
         if self.pattern:
             match = self.pattern.match(request)
             if not match:
@@ -471,9 +509,8 @@ class Route:
         if self._pass_through:
             return request
 
-        response = self.resolve(request, **context)
-
-        return response
+        result = self.resolve(request, **context)
+        return result
 
 
 class RequestPattern(Route):
@@ -504,10 +541,10 @@ class RequestPattern(Route):
         self._pass_through = pass_through
 
         if callable(method):
-            self.side_effect(method)
+            self.side_effect = method
 
-        elif response:
-            self.add_response(response)
+        if response:
+            self.return_value = response
 
 
 class SideEffectError(Exception):

--- a/respx/patterns.py
+++ b/respx/patterns.py
@@ -79,6 +79,9 @@ class Pattern:
     def __hash__(self):
         return hash((self.__class__, self.lookup, self.value))
 
+    def __eq__(self, other: object) -> bool:
+        return hash(self) == hash(other)
+
     def clean(self, value: Any) -> Any:
         """
         Clean and return pattern value.

--- a/respx/patterns.py
+++ b/respx/patterns.py
@@ -339,8 +339,8 @@ class Params(MultiItemsMixin, Pattern):
 
 class URL(Pattern):
     lookups: Tuple[Lookup, ...] = (
-        Lookup.EQUAL,
         Lookup.CONTAINS,
+        Lookup.EQUAL,
         Lookup.REGEX,
         Lookup.STARTS_WITH,
     )

--- a/respx/patterns.py
+++ b/respx/patterns.py
@@ -74,7 +74,7 @@ class Pattern:
         return _Invert(self)
 
     def __repr__(self):  # pragma: nocover
-        return f"<{self.__class__.__name__} {repr(self.value)}>"
+        return f"<{self.__class__.__name__} {self.lookup.value} {repr(self.value)}>"
 
     def __hash__(self):
         return hash((self.__class__, self.lookup, self.value))

--- a/respx/types.py
+++ b/respx/types.py
@@ -9,6 +9,7 @@ from typing import (
     Pattern,
     Sequence,
     Tuple,
+    Type,
     TypeVar,
     Union,
 )
@@ -66,3 +67,9 @@ JSONTypes = Union[str, List, Dict]
 ContentDataTypes = Union[bytes, str, JSONTypes, Callable, Exception]
 QueryParamTypes = Union[bytes, str, List[Tuple[str, Any]], Dict[str, Any]]
 RequestTypes = Union[Request, httpx.Request]
+SideEffectTypes = Union[
+    Callable,
+    Exception,
+    Type[Exception],
+    List[Union[httpx.Response, Exception, Type[Exception]]],
+]

--- a/respx/types.py
+++ b/respx/types.py
@@ -4,6 +4,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    Iterator,
     List,
     Optional,
     Pattern,
@@ -67,9 +68,11 @@ JSONTypes = Union[str, List, Dict]
 ContentDataTypes = Union[bytes, str, JSONTypes, Callable, Exception]
 QueryParamTypes = Union[bytes, str, List[Tuple[str, Any]], Dict[str, Any]]
 RequestTypes = Union[Request, httpx.Request]
+SideEffectListTypes = Union[httpx.Response, Exception, Type[Exception]]
 SideEffectTypes = Union[
     Callable,
     Exception,
     Type[Exception],
-    List[Union[httpx.Response, Exception, Type[Exception]]],
+    Sequence[SideEffectListTypes],
+    Iterator[SideEffectListTypes],
 ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -108,17 +108,17 @@ async def test_repeated_pattern(client):
 
         response1 = await client.post(url, json={})
         response2 = await client.post(url, json={})
-        response3 = await client.post(url, json={})
+        with pytest.raises(RuntimeError):
+            await client.post(url, json={})
 
         assert response1.status_code == 201
         assert response2.status_code == 409
-        assert response3.status_code == 409
-        assert respx_mock.calls.call_count == 3
+        assert respx_mock.calls.call_count == 2
 
         assert route.called is True
-        assert route.call_count == 3
+        assert route.call_count == 2
         statuses = [call.response.status_code for call in route.calls]
-        assert statuses == [201, 409, 409]
+        assert statuses == [201, 409]
 
 
 @pytest.mark.asyncio

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -162,6 +162,7 @@ def test_host_pattern(host, expected):
         (Lookup.EQUAL, 80, "https://foo.bar/", False),
         (Lookup.EQUAL, 80, "http://foo.bar/", True),
         (Lookup.EQUAL, 8080, "https://foo.bar:8080/baz/", True),
+        (Lookup.EQUAL, 8080, "https://foo.bar/baz/", False),
         (Lookup.EQUAL, 22, "//foo.bar:22/baz/", True),
         (Lookup.EQUAL, None, "//foo.bar/", True),
         (Lookup.IN, [80, 443], "http://foo.bar/", True),
@@ -258,8 +259,9 @@ def test_url_pattern(lookup, url, context, expected):
 )
 def test_url_pattern__contains(url, expected):
     _request = httpx.Request("GET", "https://foo.bar/baz/?ham=spam&egg=yolk")
+    pattern = URL(url, lookup=Lookup.CONTAINS)
     for request in (_request, encode(_request)):
-        assert bool(URL(url, lookup=Lookup.CONTAINS).match(request)) is expected
+        assert bool(pattern.match(request)) is expected
 
 
 def test_url_pattern_invalid():

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -58,6 +58,13 @@ def test_bitwise_operators(method, url, expected):
     assert bool(~pattern.match(request)) is not expected
 
 
+def test_hash():
+    p = Host("foo.bar") & Path("/baz/")
+    assert URL("//foo.bar/baz/") == p
+    p = Scheme("https") & Host("foo.bar") & Path("/baz/")
+    assert URL("https://foo.bar/baz/") == p
+
+
 def test_match_context():
     request = encode(httpx.Request("GET", "https://foo.bar/baz/?ham=spam"))
     pattern = (

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -2,7 +2,7 @@ import httpcore
 import httpx
 import pytest
 
-from respx import MockResponse, Route, Router
+from respx import MockResponse, Router
 from respx.patterns import Host, M, Method
 
 
@@ -59,35 +59,6 @@ def test_pass_through():
     assert response is not None
 
 
-def test_route_hash():
-    route = Route()
-    assert not route.is_pass_through
-    assert hash(route) == id(route)
-
-    callback = lambda req, res: req  # pragma: nocover
-    route.side_effect(callback)
-    assert not route.is_pass_through
-    assert route.has_side_effect
-    assert hash(route) == hash(callback)
-
-    route.pass_through()
-    assert route.is_pass_through
-    assert not route.has_side_effect
-    assert hash(route) == 1
-
-    route.pass_through(False)
-    assert not route.is_pass_through
-    assert hash(route) == 0
-
-    route.pass_through(None)
-    assert not route.is_pass_through
-    assert hash(route) == id(route)
-
-    request = httpx.Request("GET", "https://foo.bar/baz/")
-    response = route.match(request)
-    assert response is None
-
-
 @pytest.mark.parametrize(
     "url,expected",
     [
@@ -114,38 +85,39 @@ def test_base_url(url, expected):
 
 def test_mod_response():
     router = Router()
-    route1a = router.get("https://foo.bar") % 404
-    route1b = router.get("https://foo.bar") % dict(status_code=201)
-    route2 = router.get("https://ham.spam/egg/") % MockResponse(202)
-    route3 = router.post("https://fox.zoo/") % httpx.Response(401, json={"error": "x"})
+    route1a = router.get("https://foo.bar/baz/") % 409
+    route1b = router.get("https://foo.bar/baz/") % 404
+    route2 = router.get("https://foo.bar") % dict(status_code=201)
+    route3 = router.get("https://ham.spam/egg/") % MockResponse(202)
+    route4 = router.post("https://fox.zoo/") % httpx.Response(401, json={"error": "x"})
 
-    request = httpx.Request("GET", "https://foo.bar")
+    request = httpx.Request("GET", "https://foo.bar/baz/")
     matched_route, response = router.match(request)
     assert response.status_code == 404
-    assert matched_route is route1a
-
-    request = httpx.Request("GET", "https://foo.bar")
-    matched_route, response = router.match(request)
-    assert response.status_code == 201
     assert matched_route is route1b
     assert route1a is route1b
+
+    request = httpx.Request("GET", "https://foo.bar/")
+    matched_route, response = router.match(request)
+    assert response.status_code == 201
+    assert matched_route is route2
 
     request = httpx.Request("GET", "https://ham.spam/egg/")
     matched_route, response = router.match(request)
     assert response.status_code == 202
-    assert matched_route is route2
+    assert matched_route is route3
 
     request = httpx.Request("POST", "https://fox.zoo/")
     matched_route, response = router.match(request)
     assert response.status_code == 401
     assert response.json() == {"error": "x"}
-    assert matched_route is route3
+    assert matched_route is route4
 
 
 def test_side_effect_list():
     router = Router()
-    router.get("https://foo.bar/").side_effect(
-        [httpx.Response(404), httpx.Response(201)]
+    router.get("https://foo.bar/").mock(
+        side_effect=[httpx.Response(404), httpx.Response(201)]
     )
 
     request = httpx.Request("GET", "https://foo.bar")
@@ -161,9 +133,9 @@ def test_side_effect_list():
 
 def test_side_effect_exception():
     router = Router()
-    router.get("https://foo.bar/").side_effect(httpx.ConnectError)
-    router.get("https://ham.spam/").side_effect(httpcore.NetworkError)
-    router.get("https://egg.plant/").side_effect(httpcore.NetworkError())
+    router.get("https://foo.bar/").mock(side_effect=httpx.ConnectError)
+    router.get("https://ham.spam/").mock(side_effect=httpcore.NetworkError)
+    router.get("https://egg.plant/").mock(side_effect=httpcore.NetworkError())
 
     request = httpx.Request("GET", "https://foo.bar")
     with pytest.raises(httpx.ConnectError) as e:

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -14,16 +14,12 @@ def test_sync_transport():
         transport = SyncMockTransport(assert_all_called=False)
         assert len(w) == 1
     transport.get(url, status_code=404)
-    transport.get(url, content={"foo": "bar"})
     transport.post(url, pass_through=True)
     transport.put(url)
 
     with httpx.Client(transport=transport) as client:
         response = client.get(url)
         assert response.status_code == 404
-        response = client.get(url)
-        assert response.status_code == 200
-        assert response.json() == {"foo": "bar"}
         with pytest.raises(ValueError, match="pass_through"):
             client.post(url)
 
@@ -36,16 +32,12 @@ async def test_async_transport():
         transport = AsyncMockTransport(assert_all_called=False)
         assert len(w) == 1
     transport.get(url, status_code=404)
-    transport.get(url, content={"foo": "bar"})
     transport.post(url, pass_through=True)
     transport.put(url)
 
     async with httpx.AsyncClient(transport=transport) as client:
         response = await client.get(url)
         assert response.status_code == 404
-        response = await client.get(url)
-        assert response.status_code == 200
-        assert response.json() == {"foo": "bar"}
         with pytest.raises(ValueError, match="pass_through"):
             await client.post(url)
 


### PR DESCRIPTION
To align with python's `Mock`, the side effects are refactored, allowing stacked responses etc.

Drops...
* `Route.add_response(...)`
* `Route.side_effect(...)`

...in favour of...
* `Route.mock(return_value=..., side_effect=...)`

**Example:**
```py
route = respx.get("https://example.org/").mock(return_value=httpx.Response(200))
route = respx.get("https://example.org/").mock(side_effect=my_side_effect)
```

A route's side effect *and/or* return value (response) can now be set/changed using setters.

```py
route = respx.get("https://example.org/")
route.side_effect = my_side_effect
route.return_value = httpx.Response(200)
```

Also *stacked* responses are changed and does not repeat last one, and instead raises `StopIteration`, like `Mock` does.