### PR TITLE
Add support for patterns/lookups to the HTTP method helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ from httpx import Response
 
 @respx.mock
 def test_example():
-    my_route = respx.get("https://example.org/").mock(Response(204))
+    my_route = respx.get("https://example.org/").mock(return_value=Response(204))
     response = httpx.get("https://example.org/")
     assert my_route.called
     assert response.status_code == 204

--- a/docs/api.md
+++ b/docs/api.md
@@ -45,7 +45,7 @@ Adds a new, *optionally named*, `Route` with given [patterns](#patterns) *and/or
 
 HTTP method helpers to add routes, mimicking the [HTTPX Helper Functions](https://www.python-httpx.org/api/#helper-functions).
 
-> <code>respx.<strong>get</strong>(*url, params=None, name=None*)</strong></code>
+> <code>respx.<strong>get</strong>(*url, name=None, \*\*lookups*)</strong></code>
 
 > <code>respx.<strong>options</strong>(...)</strong></code>
 
@@ -63,13 +63,15 @@ HTTP method helpers to add routes, mimicking the [HTTPX Helper Functions](https:
 >
 > * **url** - *(optional) str | compiled regex | tuple (httpcore) | httpx.URL*  
 >   Request URL to match, *full or partial*, turned into a [URL](#url) pattern.
-> * **params** - *(optional) str | list | dict*  
->   Request query params to match, *full or partial*, turned into a [Params](#params) pattern.
->
 > * **name** - *(optional) str*  
 >   Name this route.
+> * **lookups** - *(optional) kwargs*  
+>   One or more [pattern](#patterns) keyword [lookups](#lookups), given as `<pattern>__<lookup>=value`.
 >
 > **Returns:** `Route`
+``` python
+respx.get("https://example.org/", params={"foo": "bar"})
+```
 
 ---
 
@@ -253,14 +255,16 @@ respx.route(params="foo=bar&ham=spam")
 ```
 
 ### URL
-A *shorthand* pattern wrapper, matching request *URL*, using <code>[contains](#contains)</code> as default lookup.
+Matches request *URL*.
+
+When no *lookup* is given, `url` works as a *shorthand* pattern, combining individual request *URL* parts, using the [AND](#and) operator.
 > Key: `url`  
-> Lookups: [contains](#contains), [eq](#eq), [regex](#regex), [startswith](#startswith)
+> Lookups: [eq](#eq), [regex](#regex), [startswith](#startswith)
 ``` python
-respx.route(url="//example.org/foobar/")
-respx.route(url__eq="https://example.org:8080/foobar/?ham=spam")
-respx.route(url__regex=r"https://example.org/(?P<slug>\w+)/")
-respx.route(url__startswith="https://example.org/api/")
+respx.get("//example.org/foo/")  # == M(host="example.org", path="/foo/")
+respx.get(url__eq="https://example.org:8080/foobar/?ham=spam")
+respx.get(url__regex=r"https://example.org/(?P<slug>\w+)/")
+respx.get(url__startswith="https://example.org/api/")
 ```
 
 ### Headers

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,8 +24,8 @@ from httpx import Response
 
 @respx.mock
 def test_example():
-    my_route = respx.get("https://example.org/").mock(Response(204))
-    response = httpx.get("https://example.org/")
+    my_route = respx.get("https://foo.bar/").mock(return_value=Response(204))
+    response = httpx.get("https://foo.bar/")
     assert my_route.called
     assert response.status_code == 204
 ```

--- a/respx/api.py
+++ b/respx/api.py
@@ -75,6 +75,7 @@ def add(
     pass_through: bool = False,
     alias: Optional[str] = None,
     name: Optional[str] = None,
+    **lookups: Any,
 ) -> Route:
     global mock
     return mock.add(
@@ -91,6 +92,7 @@ def add(
         pass_through=pass_through,
         alias=alias,
         name=name,
+        **lookups,
     )
 
 
@@ -108,6 +110,7 @@ def get(
     pass_through: bool = False,
     alias: Optional[str] = None,
     name: Optional[str] = None,
+    **lookups: Any,
 ) -> Route:
     global mock
     return mock.get(
@@ -123,6 +126,7 @@ def get(
         pass_through=pass_through,
         alias=alias,
         name=name,
+        **lookups,
     )
 
 
@@ -140,6 +144,7 @@ def post(
     pass_through: bool = False,
     alias: Optional[str] = None,
     name: Optional[str] = None,
+    **lookups: Any,
 ) -> Route:
     global mock
     return mock.post(
@@ -155,6 +160,7 @@ def post(
         pass_through=pass_through,
         alias=alias,
         name=name,
+        **lookups,
     )
 
 
@@ -172,6 +178,7 @@ def put(
     pass_through: bool = False,
     alias: Optional[str] = None,
     name: Optional[str] = None,
+    **lookups: Any,
 ) -> Route:
     global mock
     return mock.put(
@@ -187,6 +194,7 @@ def put(
         pass_through=pass_through,
         alias=alias,
         name=name,
+        **lookups,
     )
 
 
@@ -204,6 +212,7 @@ def patch(
     pass_through: bool = False,
     alias: Optional[str] = None,
     name: Optional[str] = None,
+    **lookups: Any,
 ) -> Route:
     global mock
     return mock.patch(
@@ -219,6 +228,7 @@ def patch(
         pass_through=pass_through,
         alias=alias,
         name=name,
+        **lookups,
     )
 
 
@@ -236,6 +246,7 @@ def delete(
     pass_through: bool = False,
     alias: Optional[str] = None,
     name: Optional[str] = None,
+    **lookups: Any,
 ) -> Route:
     global mock
     return mock.delete(
@@ -251,6 +262,7 @@ def delete(
         pass_through=pass_through,
         alias=alias,
         name=name,
+        **lookups,
     )
 
 
@@ -268,6 +280,7 @@ def head(
     pass_through: bool = False,
     alias: Optional[str] = None,
     name: Optional[str] = None,
+    **lookups: Any,
 ) -> Route:
     global mock
     return mock.head(
@@ -283,6 +296,7 @@ def head(
         pass_through=pass_through,
         alias=alias,
         name=name,
+        **lookups,
     )
 
 
@@ -300,6 +314,7 @@ def options(
     pass_through: bool = False,
     alias: Optional[str] = None,
     name: Optional[str] = None,
+    **lookups: Any,
 ) -> Route:
     global mock
     return mock.options(
@@ -315,4 +330,5 @@ def options(
         pass_through=pass_through,
         alias=alias,
         name=name,
+        **lookups,
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,15 +18,16 @@ from respx.models import MockResponse, RequestPattern, ResponseTemplate, Route
 @pytest.mark.asyncio
 async def test_http_methods(client):
     async with respx.mock:
-        url = "https://foo.bar/"
-        route = respx.get(url) % 404
-        respx.post(url).respond(201)
-        respx.post(url).respond(201)
-        respx.put(url).respond(202)
-        respx.patch(url).respond(500)
-        respx.delete(url).respond(204)
-        respx.head(url).respond(405)
-        respx.options(url).respond(status_code=501)
+        url = "https://foo.bar"
+        route = respx.get(url, path="/") % 404
+        respx.post(url, path="/").respond(200)
+        respx.post(url, path="/").respond(201)
+        respx.put(url, path="/").respond(202)
+        respx.patch(url, path="/").respond(500)
+        respx.delete(url, path="/").respond(204)
+        respx.head(url, path="/").respond(405)
+        respx.options(url, path="/").respond(status_code=501)
+        url += "/"
 
         response = httpx.get(url)
         assert response.status_code == 404
@@ -92,7 +93,7 @@ async def test_url_match(client, url, pattern):
 @pytest.mark.asyncio
 async def test_invalid_url_pattern():
     async with MockTransport() as respx_mock:
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             respx_mock.get(["invalid"])
 
 


### PR DESCRIPTION
This PR adds support for using pattern lookups in the HTTP method helper functions.

```py
respx.get("https://example.org", path__regex=...)
```