### PR TITLE
Implement content, data and json patterns

### DIFF
--- a/respx/transports.py
+++ b/respx/transports.py
@@ -21,6 +21,12 @@ class RouterTransport(Router, SyncHTTPTransport, AsyncHTTPTransport):
     ) -> SyncResponse:
         raw_request = (method, url, headers, stream)
         request = decode_request(raw_request)
+
+        # Pre-read request
+        request.read()
+        stream = request.stream  # type: ignore
+
+        # Resolve response
         response = self.resolve(request)
 
         if response is None:
@@ -43,6 +49,12 @@ class RouterTransport(Router, SyncHTTPTransport, AsyncHTTPTransport):
     ) -> AsyncResponse:
         raw_request = (method, url, headers, stream)
         request = decode_request(raw_request)
+
+        # Pre-read request
+        await request.aread()
+        stream = request.stream  # type: ignore
+
+        # Resolve response
         response = self.resolve(request)
 
         if response is None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -391,7 +391,7 @@ async def test_external_pass_through(client):  # pragma: nocover
     with respx.mock:
         # Mock pass-through call
         url = "https://httpbin.org/post"
-        route = respx.post(url, json={"foo": "bar"}).pass_through()
+        route = respx.post(url, json__foo="bar").pass_through()
 
         # Make external pass-through call
         assert route.call_count == 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -279,7 +279,6 @@ async def test_callable_content(client):
         url_pattern = re.compile(r"https://foo.bar/(?P<slug>\w+)/")
 
         def content_callback(request, slug):
-            request.read()
             content = jsonlib.loads(request.content)
             return respx.MockResponse(text=f"hello {slug}{content['x']}")
 
@@ -303,7 +302,6 @@ async def test_callable_content(client):
 @pytest.mark.asyncio
 async def test_request_callback(client):
     def callback(request, name):
-        request.read()
         if request.url.host == "foo.bar" and request.content == b'{"foo": "bar"}':
             return respx.MockResponse(
                 202,


### PR DESCRIPTION
Adds support content, data and json patterns.

Match request **content**:
```py
my_route = respx.post("https://example.org", content="foobar") % 201
response = httpx.post("https://example.org", content="foobar")
assert my_route.called
assert response.status_code == 201
```

Match request **data**:
```py
my_route = respx.post("https://example.org", data={"field": "foobar"}) % 201
response = httpx.post("https://example.org", data={"field": "foobar"})
assert my_route.called
assert response.status_code == 201
```

Match request **json**:
```py
my_route = respx.post("https://example.org", json={"name": "lundberg"}) % 201
response = httpx.post("https://example.org", json={"name": "lundberg"})
assert my_route.called
assert response.status_code == 201
```

Match request **json**, *with path digging*:
```py
my_route = respx.post("https://example.org", json__name="lundberg") % 201
response = httpx.post("https://example.org", json={"name": "lundberg"})
assert my_route.called
assert response.status_code == 201
```

Ticks one box in #87.