### PR TITLE
Refactor mocks

### DIFF
--- a/respx/__init__.py
+++ b/respx/__init__.py
@@ -1,7 +1,6 @@
 from .__version__ import __version__
-from .mocks import DeprecatedMockTransport as MockTransport
 from .models import MockResponse, Route
-from .router import Router
+from .router import DeprecatedMockTransport as MockTransport, Router
 
 from .api import (  # isort:skip
     mock,

--- a/respx/api.py
+++ b/respx/api.py
@@ -1,8 +1,8 @@
 from typing import Any, Optional, Union, overload
 
-from .mocks import MockRouter
 from .models import CallList, Route
 from .patterns import Pattern
+from .router import MockRouter
 from .types import DefaultType, URLPatternTypes
 
 mock = MockRouter(assert_all_called=False)

--- a/respx/mocks.py
+++ b/respx/mocks.py
@@ -1,134 +1,27 @@
 import inspect
-from functools import wraps
-from types import TracebackType
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, ClassVar, List
 from unittest import mock
-from warnings import warn
 
 from .models import decode_request, encode_response
-from .router import Router
 
-__all__ = ["MockRouter"]
+if TYPE_CHECKING:
+    from .router import Router  # pragma: nocover
 
-
-class MockRouter(Router):
-    _local = False
-    Mock: Type["BaseMock"]
-
-    def init(self):
-        super().init()
-        self.Mock = HTTPCoreMock
-
-    def __call__(
-        self,
-        func: Optional[Callable] = None,
-        *,
-        assert_all_called: Optional[bool] = None,
-        assert_all_mocked: Optional[bool] = None,
-        base_url: Optional[str] = None,
-    ) -> Union["MockRouter", Callable]:
-        """
-        Decorator or Context Manager.
-
-        Use decorator/manager with parentheses for local state, or without parentheses
-        for global state, i.e. shared patterns added outside of scope.
-        """
-        if func is None:
-            # Parantheses used, branch out to new nested instance.
-            # - Only stage when using local ctx `with respx.mock(...) as respx_mock:`
-            # - First stage when using local decorator `@respx.mock(...)`
-            #   FYI, global ctx `with respx.mock:` hits __enter__ directly
-            settings: Dict[str, Any] = {
-                "base_url": base_url,
-            }
-            if assert_all_called is not None:
-                settings["assert_all_called"] = assert_all_called
-            if assert_all_mocked is not None:
-                settings["assert_all_mocked"] = assert_all_mocked
-            respx_mock = self.__class__(**settings)
-            respx_mock._local = True
-            return respx_mock
-
-        # Async Decorator
-        @wraps(func)
-        async def async_decorator(*args, **kwargs):
-            assert func is not None
-            if self._local:
-                kwargs["respx_mock"] = self
-            async with self:
-                return await func(*args, **kwargs)
-
-        # Sync Decorator
-        @wraps(func)
-        def sync_decorator(*args, **kwargs):
-            assert func is not None
-            if self._local:
-                kwargs["respx_mock"] = self
-            with self:
-                return func(*args, **kwargs)
-
-        # Dispatch async/sync decorator, depening on decorated function.
-        # - Only stage when using global decorator `@respx.mock`
-        # - Second stage when using local decorator `@respx.mock(...)`
-        return async_decorator if inspect.iscoroutinefunction(func) else sync_decorator
-
-    def __enter__(self) -> "MockRouter":
-        self.start()
-        return self
-
-    def __exit__(
-        self,
-        exc_type: Type[BaseException] = None,
-        exc_value: BaseException = None,
-        traceback: TracebackType = None,
-    ) -> None:
-        self.stop(quiet=bool(exc_type is not None))
-
-    async def __aenter__(self) -> "MockRouter":
-        return self.__enter__()
-
-    async def __aexit__(self, *args: Any) -> None:
-        self.__exit__(*args)
-
-    def start(self) -> None:
-        """
-        Register transport, snapshot router and start patching.
-        """
-        self.snapshot()
-        self.Mock.register(self)
-        self.Mock.start()
-
-    def stop(self, clear: bool = True, reset: bool = True, quiet: bool = False) -> None:
-        """
-        Unregister transport and rollback router.
-        Stop patching when no registered transports left.
-        """
-        unregistered = self.Mock.unregister(self)
-
-        try:
-            if unregistered and not quiet and self._assert_all_called:
-                self.assert_all_called()
-        finally:
-            if clear:
-                self.rollback()
-            if reset:
-                self.reset()
-
-            self.Mock.stop()
+__all__ = ["HTTPCoreMock"]
 
 
 class BaseMock:
     _patches: ClassVar[List[mock._patch]]
-    routers: ClassVar[List[Router]]
+    routers: ClassVar[List["Router"]]
     targets: ClassVar[List[str]]
     _target_methods: ClassVar[List[str]]
 
     @classmethod
-    def register(cls, router: Router) -> None:
+    def register(cls, router: "Router") -> None:
         cls.routers.append(router)
 
     @classmethod
-    def unregister(cls, router: Router) -> bool:
+    def unregister(cls, router: "Router") -> bool:
         if router in cls.routers:
             cls.routers.remove(router)
             return True
@@ -231,7 +124,7 @@ class BaseMock:
 
 class HTTPCoreMock(BaseMock):
     _patches: ClassVar[List[mock._patch]] = []
-    routers: ClassVar[List[Router]] = []
+    routers: ClassVar[List["Router"]] = []
     targets = [
         "httpcore._sync.connection.SyncHTTPConnection",
         "httpcore._sync.connection_pool.SyncConnectionPool",
@@ -265,12 +158,3 @@ class HTTPCoreMock(BaseMock):
     @classmethod
     def from_httpx_response(cls, httpx_response, target, **kwargs):
         return encode_response(httpx_response)
-
-
-class DeprecatedMockTransport(MockRouter):
-    def __init__(self, *args, **kwargs):
-        warn(
-            "MockTransport used as router is deprecated. Please use `respx.mock(...)`.",
-            category=DeprecationWarning,
-        )
-        super().__init__(*args, **kwargs)

--- a/respx/transports.py
+++ b/respx/transports.py
@@ -55,16 +55,11 @@ class MockTransport(SyncHTTPTransport, AsyncHTTPTransport):
 
         # Resolve response
         response = self.handler(request)
-
         if response is None:
-            pass_through = ext.pop("pass_through", None)
-            if pass_through is None:
-                raise ValueError("pass_through not supported with manual transport")
-            raw_response = pass_through(method, url, headers, stream, ext)
-        else:
-            raw_response = encode_response(response)
+            raise ValueError("pass_through not supported when using MockTransport")
 
-        return raw_response
+        raw_response = encode_response(response)
+        return raw_response  # type: ignore
 
     async def arequest(
         self,
@@ -83,16 +78,11 @@ class MockTransport(SyncHTTPTransport, AsyncHTTPTransport):
 
         # Resolve response
         response = self.handler(request)
-
         if response is None:
-            pass_through = ext.pop("pass_through", None)
-            if pass_through is None:
-                raise ValueError("pass_through not supported with manual transport")
-            raw_response = await pass_through(method, url, headers, stream, ext)
-        else:
-            raw_response = encode_response(response)
+            raise ValueError("pass_through not supported when using MockTransport")
 
-        return raw_response
+        raw_response = encode_response(response)
+        return raw_response  # type: ignore
 
     def __exit__(
         self,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,8 +11,8 @@ import httpx
 import pytest
 
 import respx
-from respx.mocks import MockRouter
 from respx.models import Route
+from respx.router import MockRouter
 
 
 @pytest.mark.asyncio

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -4,7 +4,7 @@ import httpx
 import pytest
 
 import respx
-from respx.mocks import HTTPXMock, MockRouter
+from respx.mocks import MockRouter
 
 
 @pytest.mark.asyncio
@@ -320,7 +320,7 @@ def test_leakage(mocked_foo, mocked_ham):
     # NOTE: Including session fixtures, since they are pre-registered transports
     assert len(respx.routes) == 0
     assert len(respx.calls) == 0
-    assert len(HTTPXMock.transports) == 2
+    assert len(respx.mock.Mock.routers) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -4,7 +4,8 @@ import httpx
 import pytest
 
 import respx
-from respx.mocks import MockRouter
+from respx.mocks import HTTPCoreMock
+from respx.router import MockRouter
 
 
 @pytest.mark.asyncio
@@ -320,7 +321,7 @@ def test_leakage(mocked_foo, mocked_ham):
     # NOTE: Including session fixtures, since they are pre-registered transports
     assert len(respx.routes) == 0
     assert len(respx.calls) == 0
-    assert len(respx.mock.Mock.routers) == 2
+    assert len(HTTPCoreMock.routers) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -8,7 +8,7 @@ from httpcore._backends.asyncio import AsyncioBackend
 from httpcore._backends.trio import TrioBackend
 
 import respx
-from respx.mocks import MockRouter
+from respx.router import MockRouter
 
 
 @pytest.mark.asyncio

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -2,8 +2,7 @@ import httpcore
 import httpx
 import pytest
 
-from respx.mocks import MockRouter
-from respx.router import Router
+from respx.router import MockRouter, Router
 from respx.transports import MockTransport
 
 


### PR DESCRIPTION
This PR refactors the `httpcore` patching and the `MockTransport` to prepare for future `HTTPX` transports and mounts.