### PR TITLE
Easier support for HTTPX MockTransport

### DIFF
--- a/respx/__init__.py
+++ b/respx/__init__.py
@@ -1,6 +1,6 @@
 from .__version__ import __version__
 from .models import MockResponse, Route
-from .router import DeprecatedMockTransport as MockTransport, Router
+from .router import DeprecatedMockTransport as MockTransport, MockRouter, Router
 
 from .api import (  # isort:skip
     mock,
@@ -27,6 +27,7 @@ __all__ = [
     "__version__",
     "MockTransport",
     "MockResponse",
+    "MockRouter",
     "Router",
     "Route",
     "mock",

--- a/respx/router.py
+++ b/respx/router.py
@@ -276,6 +276,7 @@ class Router:
 
 class MockRouter(Router):
     Mock: Optional[Type[BaseMock]]
+    handler = Router.resolve
     _local = False
 
     def __init__(

--- a/respx/router.py
+++ b/respx/router.py
@@ -6,10 +6,13 @@ from warnings import warn
 
 import httpx
 
-from .mocks import HTTPCoreMock
+from .mocks import BaseMock, HTTPCoreMock, HTTPCoreMock as DefaultMock
 from .models import CallList, Route, SideEffectError
 from .patterns import Pattern, merge_patterns, parse_url_patterns
 from .types import DefaultType, URLPatternTypes
+
+Default = object
+DEFAULT = Default()
 
 
 class Router:
@@ -272,7 +275,26 @@ class Router:
 
 
 class MockRouter(Router):
+    Mock: Optional[Type[BaseMock]]
     _local = False
+
+    def __init__(
+        self,
+        *,
+        assert_all_called: bool = True,
+        assert_all_mocked: bool = True,
+        base_url: Optional[str] = None,
+        using: Optional[Union[str, Default]] = DEFAULT,
+    ) -> None:
+        super().__init__(
+            assert_all_called=assert_all_called,
+            assert_all_mocked=assert_all_mocked,
+            base_url=base_url,
+        )
+        self.Mock = {
+            "httpcore": HTTPCoreMock,
+            DEFAULT: DefaultMock,
+        }.get(using)
 
     def __call__(
         self,
@@ -281,6 +303,7 @@ class MockRouter(Router):
         assert_all_called: Optional[bool] = None,
         assert_all_mocked: Optional[bool] = None,
         base_url: Optional[str] = None,
+        using: Optional[Union[str, Default]] = DEFAULT,
     ) -> Union["MockRouter", Callable]:
         """
         Decorator or Context Manager.
@@ -295,6 +318,7 @@ class MockRouter(Router):
             #   FYI, global ctx `with respx.mock:` hits __enter__ directly
             settings: Dict[str, Any] = {
                 "base_url": base_url,
+                "using": using,
             }
             if assert_all_called is not None:
                 settings["assert_all_called"] = assert_all_called
@@ -350,15 +374,16 @@ class MockRouter(Router):
         Register transport, snapshot router and start patching.
         """
         self.snapshot()
-        HTTPCoreMock.register(self)
-        HTTPCoreMock.start()
+        if self.Mock:
+            self.Mock.register(self)
+            self.Mock.start()
 
     def stop(self, clear: bool = True, reset: bool = True, quiet: bool = False) -> None:
         """
         Unregister transport and rollback router.
         Stop patching when no registered transports left.
         """
-        unregistered = HTTPCoreMock.unregister(self)
+        unregistered = self.Mock.unregister(self) if self.Mock else True
 
         try:
             if unregistered and not quiet and self._assert_all_called:
@@ -368,8 +393,8 @@ class MockRouter(Router):
                 self.rollback()
             if reset:
                 self.reset()
-
-            HTTPCoreMock.stop()
+            if self.Mock:
+                self.Mock.stop()
 
 
 class DeprecatedMockTransport(MockRouter):

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -447,7 +447,22 @@ async def test_mock_using_none():
     @respx.mock(using=None)
     async def test(respx_mock):
         respx_mock.get("https://example.org/") % 204
-        transport = MockTransport(handler=respx_mock.resolve)
+        transport = MockTransport(handler=respx_mock.handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            response = await client.get("https://example.org/")
+            assert response.status_code == 204
+
+    await test()
+
+
+@pytest.mark.asyncio
+async def test_router_using_none():
+    router = MockRouter(using=None)
+    router.get("https://example.org/") % 204
+
+    @router
+    async def test():
+        transport = MockTransport(handler=router.handler)
         async with httpx.AsyncClient(transport=transport) as client:
             response = await client.get("https://example.org/")
             assert response.status_code == 204

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -457,7 +457,7 @@ async def test_mock_using_none():
 
 @pytest.mark.asyncio
 async def test_router_using_none():
-    router = MockRouter(using=None)
+    router = respx.MockRouter(using=None)
     router.get("https://example.org/") % 204
 
     @router


### PR DESCRIPTION
Adds support for passing `using` arg when instantiating `MockRouter` to define what patcher to use, *or* to disable patching completely.

This allows easier usage of future `HTTPX` [MockTransport](https://github.com/encode/httpx/pull/1401), if you don't want RESPX to patch the `httpcore` transports.

```py
import httpx
import respx


mock_router = respx.MockRouter(using=None)
route = mock_router.get("https://example.org/") % 204

transport = httpx.MockTransport(mock_router.handler)

with httpx.Client(transport=transport) as client:
    response = client.get("https://example.org/")
    assert response.status_code == 204
    assert route.called
```