### PR TITLE
Add support for optionally patching httpx

### DIFF
--- a/respx/models.py
+++ b/respx/models.py
@@ -496,3 +496,9 @@ class SideEffectError(Exception):
     def __init__(self, route: Route, origin: Exception) -> None:
         self.route = route
         self.origin = origin
+
+
+class PassThrough(Exception):
+    def __init__(self, message: str, *, request: httpx.Request) -> None:
+        super().__init__(message)
+        self.request = request

--- a/respx/router.py
+++ b/respx/router.py
@@ -18,7 +18,7 @@ from warnings import warn
 import httpx
 
 from .mocks import Mocker
-from .models import CallList, Route, RouteList, SideEffectError
+from .models import CallList, PassThrough, Route, RouteList, SideEffectError
 from .patterns import Pattern, merge_patterns, parse_url_patterns
 from .types import DefaultType, URLPatternTypes
 
@@ -266,10 +266,17 @@ class Router:
 
         return response
 
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        response = self.resolve(request)
+        if response is None:
+            raise PassThrough(
+                f"Request marked to pass through: {request!r}", request=request
+            )
+        return response
+
 
 class MockRouter(Router):
     Mocker: Optional[Type[Mocker]]
-    handler = Router.resolve
 
     def __init__(
         self,

--- a/respx/types.py
+++ b/respx/types.py
@@ -50,7 +50,7 @@ Response = Tuple[
     ByteStream,  # body
     dict,  # ext
 ]
-RequestHandler = Callable[[httpx.Request], Optional[httpx.Response]]
+RequestHandler = Callable[[httpx.Request], httpx.Response]
 
 HeaderTypes = Union[
     httpx.Headers,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,14 +13,18 @@ async def client():
 
 @pytest.fixture
 async def my_mock():
-    async with respx.mock(base_url="https://httpx.mock") as respx_mock:
+    async with respx.mock(
+        base_url="https://httpx.mock", using="httpcore"
+    ) as respx_mock:
         respx_mock.get("/", name="index").respond(404)
         yield respx_mock
 
 
 @pytest.fixture(scope="session")
 async def mocked_foo(event_loop):  # noqa: F811
-    async with respx.mock(base_url="https://foo.api/api/") as respx_mock:
+    async with respx.mock(
+        base_url="https://foo.api/api/", using="httpcore"
+    ) as respx_mock:
         respx_mock.get("/", name="index").respond(202)
         respx_mock.get("/bar/", name="bar")
         yield respx_mock
@@ -28,6 +32,6 @@ async def mocked_foo(event_loop):  # noqa: F811
 
 @pytest.fixture(scope="session")
 async def mocked_ham(event_loop):  # noqa: F811
-    async with respx.mock(base_url="https://ham.api") as respx_mock:
+    async with respx.mock(base_url="https://ham.api", using="httpcore") as respx_mock:
         respx_mock.get("/", name="index").respond(200)
         yield respx_mock

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -3,7 +3,7 @@ import httpx
 import pytest
 
 from respx import Route, Router
-from respx.models import RouteList
+from respx.models import PassThrough, RouteList
 from respx.patterns import Host, M, Method
 
 
@@ -51,6 +51,9 @@ def test_pass_through():
     assert matched_route is route
     assert matched_route.is_pass_through
     assert response is request
+
+    with pytest.raises(PassThrough):
+        router.handler(request)
 
     route.pass_through(False)
     matched_route, response = router.match(request)

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -2,6 +2,7 @@ import httpcore
 import httpx
 import pytest
 
+from respx.models import PassThrough
 from respx.router import MockRouter, Router
 from respx.transports import MockTransport
 
@@ -13,12 +14,12 @@ def test_sync_transport():
     router.get(url) % 404
     router.post(url).pass_through()
     router.put(url)
-    transport = MockTransport(handler=router.resolve)
+    transport = MockTransport(handler=router.handler)
 
     with httpx.Client(transport=transport) as client:
         response = client.get(url)
         assert response.status_code == 404
-        with pytest.raises(httpx.ConnectError):
+        with pytest.raises(PassThrough):
             client.post(url)
 
 
@@ -30,12 +31,12 @@ async def test_async_transport():
     router.get(url) % 404
     router.post(url).pass_through()
     router.put(url)
-    transport = MockTransport(handler=router.resolve)
+    transport = MockTransport(handler=router.handler)
 
     async with httpx.AsyncClient(transport=transport) as client:
         response = await client.get(url)
         assert response.status_code == 404
-        with pytest.raises(httpx.ConnectError):
+        with pytest.raises(PassThrough):
             await client.post(url)
 
 

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -18,7 +18,7 @@ def test_sync_transport():
     with httpx.Client(transport=transport) as client:
         response = client.get(url)
         assert response.status_code == 404
-        with pytest.raises(ValueError, match="pass_through"):
+        with pytest.raises(httpx.ConnectError):
             client.post(url)
 
 
@@ -35,7 +35,7 @@ async def test_async_transport():
     async with httpx.AsyncClient(transport=transport) as client:
         response = await client.get(url)
         assert response.status_code == 404
-        with pytest.raises(ValueError, match="pass_through"):
+        with pytest.raises(httpx.ConnectError):
             await client.post(url)
 
 


### PR DESCRIPTION
Adds httpx mocker to optionally patch `HTTPX` client rather than `httpcore` transports.

```py
@respx.mock(using="httpx")
def test():
    ...
```

If not specified, the default is still `using="httpcore"`, as of #118.