### PR TITLE
Don't patch ASGI and WSGI transports by default

### DIFF
--- a/respx/mocks.py
+++ b/respx/mocks.py
@@ -215,8 +215,6 @@ class HTTPCoreMocker(AbstractRequestMocker):
         "httpcore._async.connection.AsyncHTTPConnection",
         "httpcore._async.connection_pool.AsyncConnectionPool",
         "httpcore._async.http_proxy.AsyncHTTPProxy",
-        "httpx._transports.asgi.ASGITransport",
-        "httpx._transports.wsgi.WSGITransport",
     ]
     target_methods = ["request", "arequest"]
 

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -463,6 +463,31 @@ async def test_asgi():
             assert response.json() == {"status": "ok"}
 
 
+def test_add_remove_targets():
+    from respx.mocks import HTTPCoreMocker
+
+    target = "httpcore._sync.connection.SyncHTTPConnection"
+    assert HTTPCoreMocker.targets.count(target) == 1
+    HTTPCoreMocker.add_targets(target)
+    assert HTTPCoreMocker.targets.count(target) == 1
+
+    pre_add_count = len(HTTPCoreMocker.targets)
+    HTTPCoreMocker.add_targets(
+        "httpx._transports.asgi.ASGITransport",
+        "httpx._transports.wsgi.WSGITransport",
+    )
+    assert len(HTTPCoreMocker.targets) == pre_add_count + 2
+
+    HTTPCoreMocker.remove_targets("foobar")
+    assert len(HTTPCoreMocker.targets) == pre_add_count + 2
+
+    HTTPCoreMocker.remove_targets(
+        "httpx._transports.asgi.ASGITransport",
+        "httpx._transports.wsgi.WSGITransport",
+    )
+    assert len(HTTPCoreMocker.targets) == pre_add_count
+
+
 @pytest.mark.asyncio
 async def test_proxies():
     with respx.mock:


### PR DESCRIPTION
When using `HTTPX` as test client, i.e. testing `FastAPI`, you'll pass your asgi app to the client.

Therefore RESPX shouldn't patch those app transports by default.

This **PR** removes the asgi and wsgi transports from the default list of patch targets, but also adds support for manually adding and removing transports of your choice, i.e. re-adding any of those or adding a custom 3:rd party transport.

If anyone needs the current behaviour, patching asgi and/or wsgi transports, one now needs to do:
```python
from respx.mocks import HTTPCoreMocker


HTTPCoreMocker.add_targets(
    "httpx._transports.asgi.ASGITransport",
    "httpx._transports.wsgi.WSGITransport",
)
```