### PR TITLE
Provide error message on return value is not a httpx response instance

### DIFF
--- a/respx/router.py
+++ b/respx/router.py
@@ -255,7 +255,7 @@ class Router:
 
             else:
                 # Mocked response
-                assert isinstance(mock, httpx.Response)
+                assert isinstance(mock, httpx.Response), f"RESPX: {mock!r} is not a instance of httpx.Response"
                 response = mock
 
         except SideEffectError as error:

--- a/respx/router.py
+++ b/respx/router.py
@@ -249,6 +249,10 @@ class Router:
                 # Auto mock a successful empty response
                 response = httpx.Response(200)
 
+            elif mock == request:
+                # Pass-through request
+                response = None
+
             elif isinstance(mock, httpx.Response):
                 response = mock
 

--- a/respx/router.py
+++ b/respx/router.py
@@ -255,7 +255,9 @@ class Router:
 
             else:
                 # Mocked response
-                assert isinstance(mock, httpx.Response), f"RESPX: {mock!r} is not a instance of httpx.Response"
+                assert isinstance(
+                    mock, httpx.Response
+                ), f"RESPX: {mock!r} is not a instance of httpx.Response"
                 response = mock
 
         except SideEffectError as error:

--- a/respx/router.py
+++ b/respx/router.py
@@ -249,16 +249,11 @@ class Router:
                 # Auto mock a successful empty response
                 response = httpx.Response(200)
 
-            elif mock == request:
-                # Pass-through request
-                response = None
+            elif isinstance(mock, httpx.Response):
+                response = mock
 
             else:
-                # Mocked response
-                assert isinstance(
-                    mock, httpx.Response
-                ), f"RESPX: {mock!r} is not a instance of httpx.Response"
-                response = mock
+                raise TypeError(f"RESPX: {mock!r} is not a instance of httpx.Response")
 
         except SideEffectError as error:
             self.record(request, response=None, route=error.route)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -201,6 +201,7 @@ def test_side_effect_exception():
     router.get("https://foo.bar/").mock(side_effect=httpx.ConnectError)
     router.get("https://ham.spam/").mock(side_effect=httpcore.NetworkError)
     router.get("https://egg.plant/").mock(side_effect=httpcore.NetworkError())
+    router.get("https://hot.dog/").mock(return_value="Not a response instance")
 
     request = httpx.Request("GET", "https://foo.bar")
     with pytest.raises(httpx.ConnectError) as e:
@@ -213,6 +214,10 @@ def test_side_effect_exception():
 
     request = httpx.Request("GET", "https://egg.plant")
     with pytest.raises(httpcore.NetworkError):
+        router.resolve(request)
+
+    request = httpx.Request("GET", "https://hot.dog")
+    with pytest.raises(TypeError):
         router.resolve(request)
 
 


### PR DESCRIPTION
We already have a check for response type via router.py L257

```py
    # Mocked response
    assert isinstance(mock, httpx.Response)
    response = mock
```

But this `AssertionError` would be later catched by `Mocker.handler` in

```py
    def handler(cls, httpx_request):
        httpx_response = None
        error = None
        for router in cls.routers:
            try:
                httpx_response = router.handler(httpx_request)
            except AssertionError as e:
                error = e.args[0]  # <-- HERE
                continue
            else:
                break
        else:
            assert httpx_response, error
        return httpx_response
```

However, we do not provide a error message and thus it could not get `e.args[0]` and would raise `IndexError`

```py
    @classmethod
    def handler(cls, httpx_request):
        httpx_response = None
        error = None
        for router in cls.routers:
            try:
                httpx_response = router.handler(httpx_request)
            except AssertionError as e:
>               error = e.args[0]
E               IndexError: tuple index out of range

.venv/lib/python3.9/site-packages/respx/mocks.py:88: IndexError
```

This PR add message to it so it will show corresponding error for user.