### PR TITLE
Fix a typo for the headers example in api.md file

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -325,7 +325,7 @@ Matches request *headers*, using [contains](#contains) as default lookup.
 > Lookups: [contains](#contains), [eq](#eq)
 ``` python
 respx.route(headers={"foo": "bar", "ham": "spam"})
-respx.route(params=[("foo", "bar"), ("ham", "spam")])
+respx.route(headers=[("foo", "bar"), ("ham", "spam")])
 ```
 
 ### Cookies


### PR DESCRIPTION
Fix a typo in documentation