### PR TITLE
Support mocking responses using asgi/wsgi apps

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -11,7 +11,8 @@ docs_requirements = ("mkdocs", "mkdocs-material", "mkautodoc>=0.1.0")
 
 @nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
 def test(session):
-    session.install("--upgrade", "pytest", "pytest-asyncio", "pytest-cov", "trio")
+    deps = ["pytest", "pytest-asyncio", "pytest-cov", "trio", "starlette", "flask"]
+    session.install("--upgrade", *deps)
     session.install("-e", ".")
 
     options = session.posargs

--- a/respx/__init__.py
+++ b/respx/__init__.py
@@ -1,6 +1,12 @@
 from .__version__ import __version__
 from .models import MockResponse, Route
-from .router import DeprecatedMockTransport as MockTransport, MockRouter, Router
+from .router import (
+    ASGIHandler,
+    DeprecatedMockTransport as MockTransport,
+    MockRouter,
+    Router,
+    WSGIHandler,
+)
 
 from .api import (  # isort:skip
     mock,
@@ -28,6 +34,8 @@ __all__ = [
     "MockTransport",
     "MockResponse",
     "MockRouter",
+    "ASGIHandler",
+    "WSGIHandler",
     "Router",
     "Route",
     "mock",

--- a/respx/__init__.py
+++ b/respx/__init__.py
@@ -1,12 +1,7 @@
 from .__version__ import __version__
+from .handlers import ASGIHandler, WSGIHandler
 from .models import MockResponse, Route
-from .router import (
-    ASGIHandler,
-    DeprecatedMockTransport as MockTransport,
-    MockRouter,
-    Router,
-    WSGIHandler,
-)
+from .router import DeprecatedMockTransport as MockTransport, MockRouter, Router
 
 from .api import (  # isort:skip
     mock,

--- a/respx/handlers.py
+++ b/respx/handlers.py
@@ -1,0 +1,66 @@
+from typing import Any, Callable
+
+import httpx
+
+
+class TransportHandler:
+    def __init__(self, transport: httpx.BaseTransport) -> None:
+        self.transport = transport
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        if not isinstance(request.stream, httpx.SyncByteStream):  # pragma: nocover
+            raise RuntimeError("Attempted to route an async request to a sync app.")
+
+        (status_code, headers, stream, extensions) = self.transport.handle_request(
+            request.method.encode(),
+            request.url.raw,
+            headers=request.headers.raw,
+            stream=request.stream,
+            extensions={},
+        )
+        return httpx.Response(
+            status_code,
+            headers=headers,
+            stream=stream,
+            extensions=extensions,
+            request=request,
+        )
+
+
+class AsyncTransportHandler:
+    def __init__(self, transport: httpx.AsyncBaseTransport) -> None:
+        self.transport = transport
+
+    async def __call__(self, request: httpx.Request) -> httpx.Response:
+        if not isinstance(request.stream, httpx.AsyncByteStream):  # pragma: nocover
+            raise RuntimeError("Attempted to route a sync request to an async app.")
+
+        (
+            status_code,
+            headers,
+            stream,
+            extensions,
+        ) = await self.transport.handle_async_request(
+            request.method.encode(),
+            request.url.raw,
+            headers=request.headers.raw,
+            stream=request.stream,
+            extensions={},
+        )
+        return httpx.Response(
+            status_code,
+            headers=headers,
+            stream=stream,
+            extensions=extensions,
+            request=request,
+        )
+
+
+class WSGIHandler(TransportHandler):
+    def __init__(self, app: Callable, **kwargs: Any) -> None:
+        super().__init__(httpx.WSGITransport(app=app, **kwargs))
+
+
+class ASGIHandler(AsyncTransportHandler):
+    def __init__(self, app: Callable, **kwargs: Any) -> None:
+        super().__init__(httpx.ASGITransport(app=app, **kwargs))

--- a/respx/router.py
+++ b/respx/router.py
@@ -444,59 +444,6 @@ class MockRouter(Router):
                 self.Mocker.stop()
 
 
-class WSGIHandler:
-    def __init__(self, app: Callable, **kwargs: Any) -> None:
-        self.transport = httpx.WSGITransport(app=app, **kwargs)
-
-    def __call__(self, request: httpx.Request) -> httpx.Response:
-        if not isinstance(request.stream, httpx.SyncByteStream):  # pragma: nocover
-            raise RuntimeError("Attempted to route an async request to a sync app.")
-
-        (status_code, headers, stream, extensions) = self.transport.handle_request(
-            request.method.encode(),
-            request.url.raw,
-            headers=request.headers.raw,
-            stream=request.stream,
-            extensions={},
-        )
-        return httpx.Response(
-            status_code,
-            headers=headers,
-            stream=stream,
-            extensions=extensions,
-            request=request,
-        )
-
-
-class ASGIHandler:
-    def __init__(self, app: Callable, **kwargs: Any) -> None:
-        self.transport = httpx.ASGITransport(app=app, **kwargs)
-
-    async def __call__(self, request: httpx.Request) -> httpx.Response:
-        if not isinstance(request.stream, httpx.AsyncByteStream):  # pragma: nocover
-            raise RuntimeError("Attempted to route a sync request to an async app.")
-
-        (
-            status_code,
-            headers,
-            stream,
-            extensions,
-        ) = await self.transport.handle_async_request(
-            request.method.encode(),
-            request.url.raw,
-            headers=request.headers.raw,
-            stream=request.stream,
-            extensions={},
-        )
-        return httpx.Response(
-            status_code,
-            headers=headers,
-            stream=stream,
-            extensions=extensions,
-            request=request,
-        )
-
-
 class DeprecatedMockTransport(MockRouter):
     def __init__(self, *args, **kwargs):
         warn(

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -5,8 +5,9 @@ import httpx
 import pytest
 
 import respx
+from respx import ASGIHandler, WSGIHandler
 from respx.mocks import Mocker
-from respx.router import ASGIHandler, MockRouter, WSGIHandler
+from respx.router import MockRouter
 from respx.transports import MockTransport
 
 


### PR DESCRIPTION
This PR adds support for mocking `HTTPX` responses using an `ASGI` or `WSGI` app.

**Example:**
```py
import httpx
import respx
import pytest
from fastapi import FastAPI

app = FastAPI()


@app.get("/baz/")
async def baz():
    return {"ham": "spam"}


async def call_some_remote_api():
    async with httpx.AsyncClient() as client:
        return await client.get("https://foo.bar/baz/")


@pytest.mark.asyncio
@respx.mock
async def test():
    app_route = respx.route(host="foo.bar").mock(side_effect=respx.ASGIHandler(app))
    
    response = await call_some_remote_api()
    
    assert response.json() == {"ham": "spam"}
    assert app_route.called
```