### PR TITLE
Typo in import from examples.md

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -58,7 +58,7 @@ async def mocked_api(event_loop):  # noqa: F811
 ### Async Test Cases
 ``` python
 import httpx
-import rexpx
+import respx
 
 
 @respx.mock


### PR DESCRIPTION
rexpx -> respx