### PR TITLE
pytest + httpx

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,9 @@ Creates a mock `Router` instance, ready to be used as decorator/manager for acti
 >
 > **Returns:** `Router`
 
+!!! tip "pytest"
+    Use the `@pytest.mark.respx(...)` marker with these parameters to configure the `respx_mock` [pytest fixture](examples.md#built-in-marker).
+
 !!! note "NOTE"
     When using the *default* mock router `respx.mock`, *without settings*, `assert_all_called` is **disabled**.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,7 +2,40 @@
 
 ## pytest
 
-### Fixtures
+### Built-in Fixture
+
+RESPX includes the `respx_mock` pytest httpx *fixture*.
+
+``` python
+import httpx
+
+
+def test_fixture(respx_mock):
+    respx_mock.get("https://foo.bar/").mock(return_value=httpx.Response(204))
+    response = httpx.get("https://foo.bar/")
+    assert response.status_code == 204
+```
+
+### Built-in Marker
+
+To configure the `respx_mock` fixture, use the `respx` *marker*.
+
+``` python
+import httpx
+import pytest
+
+
+@pytest.mark.respx(base_url="https://foo.bar")
+def test_configured_fixture(respx_mock):
+    respx_mock.get("/baz/").mock(return_value=httpx.Response(204))
+    response = httpx.get("https://foo.bar/baz/")
+    assert response.status_code == 204
+```
+
+> See router [configuration](api.md#configuration) reference for more details.
+
+
+### Custom Fixtures
 ``` python
 # conftest.py
 import pytest

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,8 +40,28 @@ def test_example():
 > Read the [User Guide](guide.md) for a complete walk-through.
 
 
-!!! attention "Warning"
-    As of RESPX version `0.15.0`, the API has changed, but kept with **deprecation** warnings, later to be **broken** for backward compatibility in `0.16.0`. Read the [Upgrade Guide](upgrade.md) for an easier transision to latest release.
+### pytest + httpx
+
+For a neater `pytest` experience, RESPX includes a `respx_mock` *fixture* for easy `HTTPX` mocking, along with an optional `respx` *marker* to fine-tune the mock [settings](api.md#configuration).
+
+``` python
+import httpx
+import pytest
+
+
+def test_default(respx_mock):
+    respx_mock.get("https://foo.bar/").mock(return_value=httpx.Response(204))
+    response = httpx.get("https://foo.bar/")
+    assert response.status_code == 204
+
+
+@pytest.mark.respx(base_url="https://foo.bar")
+def test_with_marker(respx_mock):
+    respx_mock.get("/baz/").mock(return_value=httpx.Response(204))
+    response = httpx.get("https://foo.bar/baz/")
+    assert response.status_code == 204
+```
+
 
 ## Installation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: RESPX
 site_description: A utility for mocking out the Python HTTPX library.
+site_url: https://lundberg.github.io/respx/
 
 theme:
   name: "material"

--- a/respx/plugin.py
+++ b/respx/plugin.py
@@ -1,0 +1,9 @@
+import pytest
+
+import respx
+
+
+@pytest.fixture
+def respx_mock():
+    with respx.mock as _respx_mock:
+        yield _respx_mock

--- a/respx/plugin.py
+++ b/respx/plugin.py
@@ -1,9 +1,30 @@
+from typing import cast
+
 import pytest
 
 import respx
 
+from .router import MockRouter
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "respx(assert_all_called=False, assert_all_mocked=False, base_url=...): "
+        "configure the respx_mock fixture. "
+        "See https://lundberg.github.io/respx/api.html#configuration",
+    )
+
 
 @pytest.fixture
-def respx_mock():
-    with respx.mock as _respx_mock:
-        yield _respx_mock
+def respx_mock(request):
+    respx_marker = request.node.get_closest_marker("respx")
+
+    mock_router: MockRouter = (
+        respx.mock
+        if respx_marker is None
+        else cast(MockRouter, respx.mock(**respx_marker.kwargs))
+    )
+
+    with mock_router:
+        yield mock_router

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ force_grid_wrap = 0
 
 [tool:pytest]
 addopts =
+    -p no:respx
     --cov=respx
     --cov=tests
     --cov-report=term-missing

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     },
     packages=["respx"],
     package_data={"respx": ["py.typed"]},
+    entry_points={"pytest11": ["respx = respx.plugin"]},
     include_package_data=True,
     zip_safe=False,
     python_requires=">=3.6",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import pytest
 import respx
 from respx.fixtures import session_event_loop as event_loop  # noqa: F401
 
+pytest_plugins = ["pytester"]
+
 
 @pytest.fixture
 async def client():

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -353,7 +353,7 @@ async def test_nested_base_url(respx_mock):
         request1 = foobar_mock.get("/baz/") % dict(content="baz")
         request2 = foobar_mock.post(path__regex=r"(?P<slug>\w+)/?$") % dict(text="slug")
         request3 = foobar_mock.route() % dict(content="ok")
-        request4 = foobar_mock.head("http://localhost/apa/") % 204
+        request4 = foobar_mock.patch("http://localhost/egg/") % 204
 
         async with httpx.AsyncClient(base_url="https://foo.bar/api") as client:
             response = await client.get("/baz/")
@@ -368,7 +368,7 @@ async def test_nested_base_url(respx_mock):
             assert request3.called is True
             assert response.text == "ok"
 
-            response = await client.head("http://localhost/apa/")
+            response = await client.patch("http://localhost/egg/")
             assert request4.called is True
             assert response.status_code == 204
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,12 +2,23 @@ def test_respx_mock_fixture(testdir):
     testdir.makepyfile(
         """
         import httpx
+        import pytest
 
-        def test_fixture(respx_mock):
-            route = respx_mock.get("https://foo.bar/") % httpx.Response(202)
+
+        def test_plain_fixture(respx_mock):
+            route = respx_mock.get("https://foo.bar/") % 204
             response = httpx.get("https://foo.bar/")
-            assert response.status_code == 202
+            assert response.status_code == 204
+
+
+        @pytest.mark.respx(base_url="https://foo.bar", assert_all_mocked=False)
+        def test_marked_fixture(respx_mock):
+            route = respx_mock.get("/") % 204
+            response = httpx.get("https://foo.bar/")
+            assert response.status_code == 204
+            response = httpx.get("https://example.org/")
+            assert response.status_code == 200
         """
     )
     result = testdir.runpytest("-p", "respx")
-    result.assert_outcomes(passed=1)
+    result.assert_outcomes(passed=2)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,13 @@
+def test_respx_mock_fixture(testdir):
+    testdir.makepyfile(
+        """
+        import httpx
+
+        def test_fixture(respx_mock):
+            route = respx_mock.get("https://foo.bar/") % httpx.Response(202)
+            response = httpx.get("https://foo.bar/")
+            assert response.status_code == 202
+        """
+    )
+    result = testdir.runpytest("-p", "respx")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
This PR turns RESPX into a `pytest` plugin to easily mock `HTTPX` using a `respx_mock` pytest fixture together with an optional marker for detailed setup.

**Example:**
```py
import httpx


def test_foobar(respx_mock):
    foobar = respx_mock.get("https://example.org/foobar/")
    foobar.return_value = httpx.Response(200, json={"foo": "bar"})

    response = httpx.get("https://example.org/foobar/")

    assert response.json() == {"foo": "bar"}
    assert foobar.called
```

**Example with settings using marker:**
```py
import httpx
import pytest


@pytest.mark.respx(base_url="https://example.org")
def test_foobar(respx_mock):
    respx_mock.get("/foobar/") % 204
    response = httpx.get("https://example.org/foobar/")
    assert response.status_code == 204
```