### PR TITLE
Deprecate MockTransport

### DIFF
--- a/respx/__init__.py
+++ b/respx/__init__.py
@@ -1,7 +1,7 @@
 from .__version__ import __version__
 from .handlers import ASGIHandler, WSGIHandler
 from .models import MockResponse, Route
-from .router import DeprecatedMockTransport as MockTransport, MockRouter, Router
+from .router import MockRouter, Router
 
 from .api import (  # isort:skip
     mock,
@@ -26,7 +26,6 @@ from .api import (  # isort:skip
 
 __all__ = [
     "__version__",
-    "MockTransport",
     "MockResponse",
     "MockRouter",
     "ASGIHandler",

--- a/respx/models.py
+++ b/respx/models.py
@@ -19,37 +19,13 @@ import httpx
 
 from .patterns import M, Pattern
 from .types import (
-    ByteStream,
     CallableSideEffect,
+    Content,
     HeaderTypes,
-    RequestTypes,
     ResolvedResponseTypes,
-    Response,
     RouteResultTypes,
     SideEffectTypes,
 )
-
-
-def decode_request(request: RequestTypes) -> httpx.Request:
-    """
-    Build a httpx Request from httpcore request args.
-    """
-    if isinstance(request, httpx.Request):
-        return request  # pragma: nocover
-    method, url, headers, stream = request
-    return httpx.Request(method, url, headers=headers, stream=stream)
-
-
-def encode_response(response: httpx.Response) -> Response:
-    """
-    Builds a raw response tuple from httpx Response.
-    """
-    return (
-        response.status_code,
-        response.headers.raw,
-        response.stream,
-        response.extensions,
-    )
 
 
 def clone_response(response: httpx.Response, request: httpx.Request) -> httpx.Response:
@@ -99,7 +75,7 @@ class MockResponse(httpx.Response):
         self,
         status_code: Optional[int] = None,
         *,
-        content: Optional[Union[str, bytes, ByteStream]] = None,
+        content: Optional[Content] = None,
         content_type: Optional[str] = None,
         http_version: Optional[str] = None,
         **kwargs: Any,
@@ -258,11 +234,11 @@ class Route:
         status_code: int = 200,
         *,
         headers: Optional[HeaderTypes] = None,
-        content: Optional[Union[str, bytes, ByteStream]] = None,
+        content: Optional[Content] = None,
         text: Optional[str] = None,
         html: Optional[str] = None,
         json: Optional[Union[str, List, Dict]] = None,
-        stream: Optional[ByteStream] = None,
+        stream: Optional[Union[httpx.SyncByteStream, httpx.AsyncByteStream]] = None,
         content_type: Optional[str] = None,
         http_version: Optional[str] = None,
         **kwargs: Any,

--- a/respx/router.py
+++ b/respx/router.py
@@ -14,7 +14,6 @@ from typing import (
     Union,
     overload,
 )
-from warnings import warn
 
 import httpx
 
@@ -442,12 +441,3 @@ class MockRouter(Router):
                 self.reset()
             if self.Mocker:
                 self.Mocker.stop()
-
-
-class DeprecatedMockTransport(MockRouter):
-    def __init__(self, *args, **kwargs):
-        warn(
-            "MockTransport used as router is deprecated. Please use `respx.mock(...)`.",
-            category=DeprecationWarning,
-        )
-        super().__init__(*args, **kwargs)

--- a/respx/types.py
+++ b/respx/types.py
@@ -1,8 +1,10 @@
 from typing import (
     Any,
+    AsyncIterable,
     Awaitable,
     Callable,
     Dict,
+    Iterable,
     Iterator,
     List,
     Optional,
@@ -23,33 +25,7 @@ URL = Tuple[
     bytes,  # path
 ]
 Headers = List[Tuple[bytes, bytes]]
-ByteStream = Union[httpx.SyncByteStream, httpx.AsyncByteStream]
-Request = Tuple[
-    bytes,  # http method
-    URL,
-    Headers,
-    ByteStream,  # body
-]
-SyncResponse = Tuple[
-    int,  # status code
-    Headers,
-    httpx.SyncByteStream,  # body
-    dict,  # ext
-]
-AsyncResponse = Tuple[
-    int,  # status code
-    Headers,
-    httpx.AsyncByteStream,  # body
-    dict,  # ext
-]
-Response = Tuple[
-    int,  # status code
-    Headers,
-    ByteStream,  # body
-    dict,  # ext
-]
-RequestHandler = Callable[[httpx.Request], httpx.Response]
-AsyncRequestHandler = Callable[[httpx.Request], Awaitable[httpx.Response]]
+Content = Union[str, bytes, Iterable[bytes], AsyncIterable[bytes]]
 
 HeaderTypes = Union[
     httpx.Headers,
@@ -66,7 +42,6 @@ URLPatternTypes = Union[str, Pattern[str], URL, httpx.URL]
 QueryParamTypes = Union[
     bytes, str, List[Tuple[str, Any]], Dict[str, Any], Tuple[Tuple[str, Any], ...]
 ]
-RequestTypes = Union[Request, httpx.Request]
 
 ResolvedResponseTypes = Optional[Union[httpx.Request, httpx.Response]]
 RouteResultTypes = Union[ResolvedResponseTypes, Awaitable[ResolvedResponseTypes]]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,6 @@ import json as jsonlib
 import os
 import re
 import socket
-import warnings
 from unittest import mock
 
 import httpcore
@@ -605,9 +604,3 @@ async def test_async_post_content(kwargs):
         async with httpx.AsyncClient() as client:
             response = await client.post("https://foo.bar/", **kwargs)
             assert response.status_code == 201
-
-
-def test_deprecated_mock_transport():
-    with warnings.catch_warnings(record=True) as w:
-        respx.MockTransport()
-        assert len(w) == 1


### PR DESCRIPTION
Deprecating the `MockTransport` and refactor to internally use the *"new"* `httpx.MockTransport`, which looks pretty much identical to ours.

Type hints and utilities is also cleaned up in the PR.