### PR TITLE
Only publish for upstream repo, avoid failure on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         pip install --upgrade nox
         nox -s docs
     - name: Publish
-      if: github.repository == 'lundberg/respx'
+      if: github.repository_owner == 'lundberg'
       run: |
         git config user.email ${{ secrets.GITHUB_EMAIL }}
         git remote set-url origin https://${{ secrets.GITHUB_USER }}:${{ secrets.GITHUB_PAGES_TOKEN }}@github.com/lundberg/respx.git

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,7 @@ jobs:
         pip install --upgrade nox
         nox -s docs
     - name: Publish
+      if: github.repository == 'lundberg/respx'
       run: |
         git config user.email ${{ secrets.GITHUB_EMAIL }}
         git remote set-url origin https://${{ secrets.GITHUB_USER }}:${{ secrets.GITHUB_PAGES_TOKEN }}@github.com/lundberg/respx.git


### PR DESCRIPTION
Skip the publish step when running on forks, as it fails when secrets have not been set.