### PR TITLE
Reproduce bug httpx.ResponseNotRead: Attempted to access

### DIFF
--- a/tests/insights/README.md
+++ b/tests/insights/README.md
@@ -1,0 +1,10 @@
+
+# Create and activate venv in current folder
+
+`virtualenv -p <python version> venv`
+
+`source venv/bin/activate`
+
+# Run test
+
+`pytest tests/test.py`

--- a/tests/insights/main.py
+++ b/tests/insights/main.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI, responses, Body
+import typing as t
+import httpx
+
+
+app = FastAPI()
+
+
+async def hook(response: httpx.Response) -> None:
+    response.raise_for_status()
+
+
+@app.post('/endpoint')
+async def endpoint(
+    data: t.Dict[str, str] = Body(...)
+) -> responses.JSONResponse:
+    async with httpx.AsyncClient(event_hooks={'response': [hook]}) as client:
+        try:
+            await client.post('https://test.com/post', json=data)
+        except httpx.HTTPStatusError as e:
+            return responses.JSONResponse(status_code=400, content={'status': 'error', 'detail': e.response.text})
+
+    return responses.JSONResponse(content={'status': 'ok'})

--- a/tests/insights/requirements.txt
+++ b/tests/insights/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.68.1
+httpx==0.19.0
+pydantic==1.8.2
+uvicorn==0.15.0
+
+pytest==6.2.5
+respx==0.17.1
+pytest-asyncio==0.15.1
+requests[socks]==2.25.1

--- a/tests/insights/setup.cfg
+++ b/tests/insights/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+junit_family = xunit1

--- a/tests/insights/tests/test.py
+++ b/tests/insights/tests/test.py
@@ -1,0 +1,29 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from main import app
+import typing as t
+import respx
+
+
+@pytest.fixture()
+def fast_api_app() -> FastAPI:
+    return app
+
+
+@pytest.fixture()
+def client_app(fast_api_app: FastAPI) -> t.Generator[TestClient, None, None]:
+    with TestClient(fast_api_app) as client:
+        yield client
+
+
+def test_app_for_test(client_app: TestClient) -> None:
+    with respx.mock(
+        base_url='https://test.com',
+        assert_all_called=True,
+        assert_all_mocked=True,
+    ) as respx_mock:
+        respx_mock.post('/post').respond(status_code=400, text='Bad request')
+        response = client_app.post('/endpoint', json={'body': 'data'})
+        assert response.status_code == 400
+        assert response.json()['detail'] == 'Bad request'


### PR DESCRIPTION
Hello.

For some reason `httpx==0.19.0` is not working with `respx==0.17.1` properly if `httpx.AsyncClient` using hooks behavior. If run the current test it will fail with the exception

```
client_app = <starlette.testclient.TestClient object at 0x7f4f71eb1640>

    def test_app_for_test(client_app: TestClient) -> None:
        with respx.mock(
            base_url='https://test.com',
            assert_all_called=True,
            assert_all_mocked=True,
        ) as respx_mock:
            respx_mock.post('/post').respond(status_code=400, text='Bad request')
>           response = client_app.post('/endpoint', json={'body': 'data'})

tests/test.py:27: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../../respx_bug/venv/lib/python3.8/site-packages/requests/sessions.py:590: in post
    return self.request('POST', url, data=data, json=json, **kwargs)
../../../respx_bug/venv/lib/python3.8/site-packages/starlette/testclient.py:415: in request
    return super().request(
../../../respx_bug/venv/lib/python3.8/site-packages/requests/sessions.py:542: in request
    resp = self.send(prep, **send_kwargs)
../../../respx_bug/venv/lib/python3.8/site-packages/requests/sessions.py:655: in send
    r = adapter.send(request, **kwargs)
../../../respx_bug/venv/lib/python3.8/site-packages/starlette/testclient.py:243: in send
    raise exc from None
../../../respx_bug/venv/lib/python3.8/site-packages/starlette/testclient.py:240: in send
    loop.run_until_complete(self.app(scope, receive, send))
/home/t4ks/.pyenv/versions/3.8.8/lib/python3.8/asyncio/base_events.py:616: in run_until_complete
    return future.result()
../../../respx_bug/venv/lib/python3.8/site-packages/fastapi/applications.py:208: in __call__
    await super().__call__(scope, receive, send)
../../../respx_bug/venv/lib/python3.8/site-packages/starlette/applications.py:112: in __call__
    await self.middleware_stack(scope, receive, send)
../../../respx_bug/venv/lib/python3.8/site-packages/starlette/middleware/errors.py:181: in __call__
    raise exc from None
../../../respx_bug/venv/lib/python3.8/site-packages/starlette/middleware/errors.py:159: in __call__
    await self.app(scope, receive, _send)
../../../respx_bug/venv/lib/python3.8/site-packages/starlette/exceptions.py:82: in __call__
    raise exc from None
../../../respx_bug/venv/lib/python3.8/site-packages/starlette/exceptions.py:71: in __call__
    await self.app(scope, receive, sender)
../../../respx_bug/venv/lib/python3.8/site-packages/starlette/routing.py:580: in __call__
    await route.handle(scope, receive, send)
../../../respx_bug/venv/lib/python3.8/site-packages/starlette/routing.py:241: in handle
    await self.app(scope, receive, send)
../../../respx_bug/venv/lib/python3.8/site-packages/starlette/routing.py:52: in app
    response = await func(request)
../../../respx_bug/venv/lib/python3.8/site-packages/fastapi/routing.py:226: in app
    raw_response = await run_endpoint_function(
../../../respx_bug/venv/lib/python3.8/site-packages/fastapi/routing.py:159: in run_endpoint_function
    return await dependant.call(**values)
main.py:21: in endpoint
    return responses.JSONResponse(status_code=400, content={'status': 'error', 'detail': e.response.text})
../../../respx_bug/venv/lib/python3.8/site-packages/httpx/_models.py:1314: in text
    content = self.content

self = <Response [400 Bad Request]>

    @property
    def content(self) -> bytes:
        if not hasattr(self, "_content"):
>           raise ResponseNotRead()
E           httpx.ResponseNotRead: Attempted to access streaming response content, without having called `read()`.
```


but if change the code and remove the hook and check response status inside the main function everything works as expected.
