### PR TITLE
Downgrade HTTPX requirement to 0.20.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     python_requires=">=3.6",
-    install_requires=["httpx>=1.0.0b0"],
+    install_requires=["httpx>=0.20.0"],
 )


### PR DESCRIPTION
Stable `HTTPX` version `0.20.0` is now released with the same changes as the `1.0.0b0` allowing us to release a stable `RESPX` version `0.18.0`, supporting the new API and "lowering" the required HTTPX version.