### PR TITLE
Fix CallList assertion error message

### DIFF
--- a/respx/models.py
+++ b/respx/models.py
@@ -48,6 +48,10 @@ class Call(NamedTuple):
 
 
 class CallList(list, mock.NonCallableMock):
+    def __init__(self, *args, name="respx", **kwargs):
+        super().__init__(*args, **kwargs)
+        mock.NonCallableMock.__init__(self, name=name)
+
     @property
     def called(self) -> bool:  # type: ignore
         return bool(self)
@@ -106,7 +110,7 @@ class Route:
         self._pass_through: bool = False
         self._name: Optional[str] = None
         self._snapshots: List[Tuple] = []
-        self.calls = CallList()
+        self.calls = CallList(name=self)
         self.snapshot()
 
     def __eq__(self, other: object) -> bool:
@@ -196,7 +200,7 @@ class Route:
                 self._return_value,
                 side_effect,
                 self._pass_through,
-                CallList(self.calls),
+                CallList(self.calls, name=self),
             ),
         )
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -347,6 +347,13 @@ def test_rollback():
     assert route.call_count == 1
     assert route.return_value.status_code == 418
 
+    router.snapshot()  # 3. directly rollback, should be identical
+    router.rollback()
+    assert len(router.routes) == 2
+    assert router.calls.call_count == 2
+    assert route.call_count == 1
+    assert route.return_value.status_code == 418
+
     router.patch("https://foo.bar/")
     assert len(router.routes) == 3
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -33,6 +33,12 @@ async def backend_test(backend):
     assert respx.calls.call_count == len(respx.calls)
     assert respx.calls.call_count == 0
 
+    with pytest.raises(AssertionError, match="Expected 'respx' to have been called"):
+        respx.calls.assert_called_once()
+
+    with pytest.raises(AssertionError, match="Expected '<Route name='get_foobar'"):
+        foobar1.calls.assert_called_once()
+
     async with httpx.AsyncClient() as client:
         get_response = await client.get(url)
         del_response = await client.delete(url)


### PR DESCRIPTION
When `respx.calls.assert_called_once()` *(and friends)* fails the assertion check, the python built-in error message crashes when being formatted.

This PR fixes this, but also enhances the output of these assertion messages, e.g. what route failed.