### PR TITLE
Router rollback settings

### DIFF
--- a/respx/router.py
+++ b/respx/router.py
@@ -68,7 +68,15 @@ class Router:
         # Snapshot current routes and calls
         routes = RouteList(self.routes)
         calls = CallList(self.calls)
-        self._snapshots.append((routes, calls, self._bases, self._assert_all_called, self._assert_all_mocked))
+        self._snapshots.append(
+            (
+                routes,
+                calls,
+                self._bases,
+                self._assert_all_called,
+                self._assert_all_mocked,
+            )
+        )
 
         # Snapshot each route state
         for route in routes:
@@ -82,7 +90,13 @@ class Router:
             return
 
         # Revert added routes and calls to last snapshot
-        routes, calls, bases, assert_all_called, assert_all_mocked = self._snapshots.pop()
+        (
+            routes,
+            calls,
+            bases,
+            assert_all_called,
+            assert_all_mocked,
+        ) = self._snapshots.pop()
         self.routes[:] = routes
         self.calls[:] = calls
         self._bases = bases
@@ -315,10 +329,12 @@ class Router:
         assert isinstance(resolved.response, httpx.Response)
         return resolved.response
 
-    def configure(self,
-                  assert_all_called: bool = None,
-                  assert_all_mocked: bool = None,
-                  base_url: Optional[str] = None):
+    def configure(
+        self,
+        assert_all_called: bool = None,
+        assert_all_mocked: bool = None,
+        base_url: Optional[str] = None,
+    ) -> None:
         self.snapshot()
 
         if base_url is not None:

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -514,3 +514,24 @@ def test_routelist__replaces_same_name_other_pattern_other_name():
     routes.add(foobar2, name="foobar")
     assert list(routes) == [foobar2]
     assert routes["foobar"] is foobar1
+
+def test_configure():
+    router = Router(assert_all_called=True, assert_all_mocked=True)
+
+    assert router._assert_all_mocked == True
+    router.configure(assert_all_mocked=False)
+    assert router._assert_all_mocked == False
+    router.rollback();
+    assert router._assert_all_mocked == True
+
+    assert router._assert_all_called == True
+    router.configure(assert_all_called=False)
+    assert router._assert_all_called == False
+    router.rollback();
+    assert router._assert_all_called == True
+
+    old_bases = router._bases
+    router.configure(base_url="https://foo.bar/api/")
+    assert router._bases != old_bases
+    router.rollback();
+    assert router._bases == old_bases

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -515,23 +515,24 @@ def test_routelist__replaces_same_name_other_pattern_other_name():
     assert list(routes) == [foobar2]
     assert routes["foobar"] is foobar1
 
+
 def test_configure():
     router = Router(assert_all_called=True, assert_all_mocked=True)
 
-    assert router._assert_all_mocked == True
+    assert router._assert_all_mocked
     router.configure(assert_all_mocked=False)
-    assert router._assert_all_mocked == False
-    router.rollback();
-    assert router._assert_all_mocked == True
+    assert not router._assert_all_mocked
+    router.rollback()
+    assert router._assert_all_mocked
 
-    assert router._assert_all_called == True
+    assert router._assert_all_called
     router.configure(assert_all_called=False)
-    assert router._assert_all_called == False
-    router.rollback();
-    assert router._assert_all_called == True
+    assert not router._assert_all_called
+    router.rollback()
+    assert router._assert_all_called
 
     old_bases = router._bases
     router.configure(base_url="https://foo.bar/api/")
     assert router._bases != old_bases
-    router.rollback();
+    router.rollback()
     assert router._bases == old_bases


### PR DESCRIPTION
Adds router settings to the rollback functionality, as well as a function `configure()` which allows changing the settings of the router, creating a new snapshot.

Closes #181 