### PR TITLE
Use Session.notify when chaining nox sessions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -41,7 +41,7 @@ def lint(session):
     session.run("isort", "--project=respx", *source_files)
     session.run("black", "--target-version=py36", *source_files)
 
-    check(session)
+    session.notify("check")
 
 
 @nox.session


### PR DESCRIPTION
Use [nox.sessions.Session.notify](https://nox.thea.codes/en/stable/config.html#nox.sessions.Session.notify) instead of directly calling other nox session functions.

Should result in _slightly_ nicer log output from nox, as it detects that multiple sessions has run.

__Old output:__
<img width="574" alt="old_output" src="https://user-images.githubusercontent.com/3703560/141471410-180f01b3-7c66-44dd-8d63-c73c30abc75f.png">

__New output:__
<img width="568" alt="new_output" src="https://user-images.githubusercontent.com/3703560/141471310-b9693fae-77e7-4e27-907d-ad046ed0feb8.png">

