### PR TITLE
Allow first path segments containing colons

### DIFF
--- a/respx/patterns.py
+++ b/respx/patterns.py
@@ -388,7 +388,8 @@ class Path(Pattern):
         return request.url.path
 
     def strip_base(self, value: str) -> str:
-        value = urljoin("/", value[len(self.base.value) :])
+        value = value[len(self.base.value) :]
+        value = "/" + value if not value.startswith("/") else value
         return value
 
 

--- a/respx/router.py
+++ b/respx/router.py
@@ -296,7 +296,7 @@ class Router:
                 # Await async side effect and wrap any exception
                 if inspect.isawaitable(prospect):
                     try:
-                        prospect = await prospect  # type: ignore
+                        prospect = await prospect
                     except Exception as error:
                         raise SideEffectError(route, origin=error) from error
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -95,6 +95,7 @@ def test_pass_through():
         ("http://foo.bar/api/baz/", {"url": "/baz/"}, False),
         ("https://ham.spam/api/baz/", {"url": "/baz/"}, False),
         ("https://foo.bar/baz/", {"url": "/baz/"}, False),
+        ("https://foo.bar/api/hej:svejs", {"url": "/hej:svejs"}, True),
     ],
 )
 def test_base_url(url, lookups, expected):


### PR DESCRIPTION
Using `urljoin` for merging path segments where the first segment contains a colon will cause the base to be ignored.
```python
>>> urljoin("/", "foo:bar")
'foo:bar'
```

See [RFC3986](https://www.rfc-editor.org/rfc/rfc3986#section-4.2)
> A path segment that contains a colon character (e.g., "this:that") cannot be used as the first segment of a relative-path reference, as it would be mistaken for a scheme name. Such a segment must be preceded by a dot-segment (e.g., "./this:that") to make a relative-path reference.

The easiest way is probably to not use `urljoin` and simply add a leading `/` when needed.

