### PR TITLE
Add light/dark mode toggle to docs

### DIFF
--- a/docs/stylesheets/slate.css
+++ b/docs/stylesheets/slate.css
@@ -1,0 +1,7 @@
+[data-md-color-scheme="slate"] {
+  --md-hue: 245; 
+  --md-typeset-a-color: #9772d7;
+  --md-default-bg-color: hsla(var(--md-hue),15%,11%,1);
+  --md-footer-bg-color: hsla(var(--md-hue),15%,5%,0.87);
+  --md-footer-bg-color--dark: hsla(var(--md-hue),15%,1%,1);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,11 +4,26 @@ site_url: https://lundberg.github.io/respx/
 
 theme:
   name: "material"
-  palette:
-    primary: "deep purple"
-    accent: "deep purple"
   icon:
     logo: "material/school"
+  palette:
+    - scheme: default
+      media: "(prefers-color-scheme: light)"
+      primary: "deep purple"
+      accent: "deep purple"
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      media: "(prefers-color-scheme: dark)"
+      primary: "deep purple"
+      accent: "deep purple"
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+extra_css:
+  - stylesheets/slate.css
 
 repo_name: lundberg/respx
 repo_url: https://github.com/lundberg/respx


### PR DESCRIPTION
Adds a toggle icon to the docs site for selecting light or dark mode.