### PR TITLE
Use pytest asyncio auto mode

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,7 @@ def test(session):
     session.run("pytest", "-v", *options)
 
 
-@nox.session
+@nox.session(python="3.6")
 def check(session):
     session.install("--upgrade", "flake8-bugbear", "mypy", *lint_requirements)
     session.install("-e", ".")

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [flake8]
 max-line-length = 88
-ignore = E501,E266,E731,W503,E203
+ignore = E501,E266,E731,W503,E203,B024
 exclude = .git
 show-source = true
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ addopts =
     --cov-report=xml
     --cov-fail-under 100
     -rxXs
+asyncio_mode = auto
 
 [coverage:run]
 source = respx,tests


### PR DESCRIPTION
Leaving asyncio pytest markers due to `python 3.6`.

Fixes #207 