### PR TITLE
Reduce number of `Optional` return values

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ lint_requirements = ("flake8", "black", "isort")
 docs_requirements = ("mkdocs", "mkdocs-material", "mkautodoc>=0.1.0")
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"])
 def test(session):
     deps = ["pytest", "pytest-asyncio", "pytest-cov", "trio", "starlette", "flask"]
     session.install("--upgrade", *deps)

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ def check(session):
     session.run("black", "--check", "--diff", "--target-version=py36", *source_files)
     session.run("isort", "--check", "--diff", "--project=respx", *source_files)
     session.run("flake8", *source_files)
-    session.run("mypy", "respx")
+    session.run("mypy")
 
 
 @nox.session

--- a/respx/models.py
+++ b/respx/models.py
@@ -430,6 +430,8 @@ class RouteList:
         """
         Re-set all routes to given routes.
         """
+        if (i.start, i.stop, i.step) != (None, None, None):
+            raise TypeError("Can't slice assign routes")
         self._routes = list(routes._routes)
         self._names = dict(routes._names)
 

--- a/respx/models.py
+++ b/respx/models.py
@@ -48,21 +48,21 @@ class Call(NamedTuple):
 
 
 class CallList(list, mock.NonCallableMock):
-    def __init__(self, *args, name="respx", **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, *args: Sequence[Call], name: Any = "respx") -> None:
+        super().__init__(*args)
         mock.NonCallableMock.__init__(self, name=name)
 
     @property
-    def called(self) -> bool:  # type: ignore
+    def called(self) -> bool:  # type: ignore[override]
         return bool(self)
 
     @property
-    def call_count(self) -> int:  # type: ignore
+    def call_count(self) -> int:  # type: ignore[override]
         return len(self)
 
     @property
-    def last(self) -> Optional[Call]:
-        return self[-1] if self else None
+    def last(self) -> Call:
+        return self[-1]
 
     def record(
         self, request: httpx.Request, response: Optional[httpx.Response]

--- a/respx/models.py
+++ b/respx/models.py
@@ -161,7 +161,7 @@ class Route:
         raise NotImplementedError("Can't set name on route.")
 
     @property
-    def pattern(self) -> Optional[Pattern]:
+    def pattern(self) -> Pattern:
         return self._pattern
 
     @pattern.setter

--- a/respx/models.py
+++ b/respx/models.py
@@ -174,7 +174,9 @@ class Route:
         self._return_value = return_value
 
     @property
-    def side_effect(self) -> Optional[SideEffectTypes]:
+    def side_effect(
+        self,
+    ) -> Optional[Union[SideEffectTypes, Sequence[SideEffectListTypes]]]:
         return self._side_effect
 
     @side_effect.setter
@@ -230,7 +232,9 @@ class Route:
         self,
         return_value: Optional[httpx.Response] = None,
         *,
-        side_effect: Optional[SideEffectTypes] = None,
+        side_effect: Optional[
+            Union[SideEffectTypes, Sequence[SideEffectListTypes]]
+        ] = None,
     ) -> "Route":
         self.return_value = return_value
         self.side_effect = side_effect

--- a/respx/models.py
+++ b/respx/models.py
@@ -44,7 +44,13 @@ def clone_response(response: httpx.Response, request: httpx.Request) -> httpx.Re
 
 class Call(NamedTuple):
     request: httpx.Request
-    response: Optional[httpx.Response]
+    optional_response: Optional[httpx.Response]
+
+    @property
+    def response(self) -> httpx.Response:
+        if self.optional_response is None:
+            raise ValueError(f"{self!r} has no response")
+        return self.optional_response
 
 
 class CallList(list, mock.NonCallableMock):
@@ -67,7 +73,7 @@ class CallList(list, mock.NonCallableMock):
     def record(
         self, request: httpx.Request, response: Optional[httpx.Response]
     ) -> Call:
-        call = Call(request=request, response=response)
+        call = Call(request=request, optional_response=response)
         self.append(call)
         return call
 

--- a/respx/models.py
+++ b/respx/models.py
@@ -52,6 +52,10 @@ class Call(NamedTuple):
             raise ValueError(f"{self!r} has no response")
         return self.optional_response
 
+    @property
+    def has_response(self) -> bool:
+        return self.optional_response is not None
+
 
 class CallList(list, mock.NonCallableMock):
     def __init__(self, *args: Sequence[Call], name: Any = "respx") -> None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,10 @@ skip_covered = True
 show_missing = True
 
 [mypy]
+python_version = 3.6
+files = respx,tests
+pretty = True
+
 no_implicit_reexport = True
 no_implicit_optional = True
 strict_equality = True
@@ -52,4 +56,13 @@ warn_unreachable = True
 show_error_codes = True
 
 [mypy-pytest.*]
+ignore_missing_imports = True
+
+[mypy-trio.*]
+ignore_missing_imports = True
+
+[mypy-flask.*]
+ignore_missing_imports = True
+
+[mypy-starlette.*]
 ignore_missing_imports = True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -99,7 +99,7 @@ async def test_url_match(client, url, pattern):
 async def test_invalid_url_pattern():
     async with MockRouter() as respx_mock:
         with pytest.raises(TypeError):
-            respx_mock.get(["invalid"])
+            respx_mock.get(["invalid"])  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio
@@ -277,7 +277,10 @@ async def test_raising_content(client):
     async with MockRouter() as respx_mock:
         url = "https://foo.bar/"
         request = respx_mock.get(url)
-        request.side_effect = httpx.ConnectTimeout("X-P", request=None)
+        request.side_effect = httpx.ConnectTimeout(
+            "X-P",
+            request=None,  # type: ignore[arg-type]
+        )
         with pytest.raises(httpx.ConnectTimeout):
             await client.get(url)
 
@@ -357,7 +360,9 @@ async def test_request_callback(client):
         assert response.text == "hello lundberg"
 
         with pytest.raises(TypeError):
-            respx_mock.get("https://ham.spam/").mock(side_effect=lambda req: "invalid")
+            respx_mock.get("https://ham.spam/").mock(
+                side_effect=lambda req: "invalid"  # type: ignore[arg-type,return-value]
+            )
             await client.get("https://ham.spam/")
 
         with pytest.raises(httpx.NetworkError):
@@ -527,10 +532,10 @@ def test_add():
         assert respx.routes["foobar"].called
 
         with pytest.raises(TypeError):
-            respx.add(route, status_code=418)  # pragma: nocover
+            respx.add(route, status_code=418)  # type: ignore[call-arg]
 
         with pytest.raises(ValueError):
-            respx.add("GET")  # pragma: nocover
+            respx.add("GET")  # type: ignore[arg-type]
 
         with pytest.raises(NotImplementedError):
             route.name = "spam"
@@ -555,7 +560,7 @@ def test_respond():
             route.respond(content={})
 
         with pytest.raises(TypeError, match="content can only be"):
-            route.respond(content=Exception())
+            route.respond(content=Exception())  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -296,6 +296,7 @@ async def test_raising_content(client):
 
         assert route.call_count == 2
         assert route.calls.last.request is not None
+        assert route.calls.last.has_response is False
         with pytest.raises(ValueError, match="has no response"):
             assert route.calls.last.response
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -293,7 +293,8 @@ async def test_raising_content(client):
 
         assert route.call_count == 2
         assert route.calls.last.request is not None
-        assert route.calls.last.response is None
+        with pytest.raises(ValueError, match="has no response"):
+            assert route.calls.last.response
 
 
 @pytest.mark.asyncio

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -346,7 +346,7 @@ async def test_router_return_type_misuse():
     route = router.get("https://hot.dog/")
 
     with pytest.raises(TypeError):
-        route.return_value = "not-a-httpx-response"
+        route.return_value = "not-a-httpx-response"  # type: ignore[assignment]
 
 
 @pytest.mark.asyncio
@@ -545,7 +545,7 @@ async def test_router_using__none():
 
 def test_router_using__invalid():
     with pytest.raises(ValueError, match="using"):
-        respx.MockRouter(using=123).using
+        respx.MockRouter(using=123).using  # type: ignore[arg-type]
 
 
 def test_mocker_subclass():

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -317,25 +317,25 @@ async def test_configured_router_reuse(client):
     with router:
         route.return_value = httpx.Response(202)
         response = await client.get("https://foo/bar/")
-        assert route.called is True
+        assert route.called == True  # noqa: E712
         assert response.status_code == 202
         assert router.calls.call_count == 1
         assert respx.calls.call_count == 0
 
     assert len(router.routes) == 1
-    assert route.called is False
+    assert route.called == False  # noqa: E712
     assert router.calls.call_count == 0
 
     async with router:
         assert router.calls.call_count == 0
         response = await client.get("https://foo/bar/")
-        assert route.called is True
+        assert route.called == True  # noqa: E712
         assert response.status_code == 404
         assert router.calls.call_count == 1
         assert respx.calls.call_count == 0
 
     assert len(router.routes) == 1
-    assert route.called is False
+    assert route.called == False  # noqa: E712
     assert router.calls.call_count == 0
     assert respx.calls.call_count == 0
 
@@ -396,7 +396,7 @@ async def test_start_stop(client):
     try:
         respx.start()
         response = await client.get(url)
-        assert request.called is True
+        assert request.called == True  # noqa: E712
         assert response.status_code == 202
         assert response.text == ""
         assert respx.calls.call_count == 1
@@ -404,12 +404,12 @@ async def test_start_stop(client):
         respx.stop(clear=False, reset=False)
         assert len(respx.routes) == 1
         assert respx.calls.call_count == 1
-        assert request.called is True
+        assert request.called == True  # noqa: E712
 
         respx.reset()
         assert len(respx.routes) == 1
         assert respx.calls.call_count == 0
-        assert request.called is False
+        assert request.called == False  # noqa: E712
 
         respx.clear()
         assert len(respx.routes) == 0

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -15,6 +15,7 @@ from respx.patterns import (
     Lookup,
     M,
     Method,
+    Noop,
     Params,
     Path,
     Pattern,
@@ -64,6 +65,18 @@ def test_match_context():
     match = pattern.match(request)
     assert bool(match)
     assert match.context == {"host": "foo.bar", "slug": "baz"}
+
+
+def test_noop_pattern():
+    assert bool(Noop()) is False
+    assert bool(Noop().match(httpx.Request("GET", "https://example.org"))) is True
+    assert list(filter(None, [Noop()])) == []
+    assert repr(Noop()) == "<Noop>"
+    assert isinstance(~Noop(), Noop)
+    assert Method("GET") & Noop() == Method("GET")
+    assert Noop() & Method("GET") == Method("GET")
+    assert Method("GET") | Noop() == Method("GET")
+    assert Noop() | Method("GET") == Method("GET")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -37,7 +37,7 @@ def test_remote_pass_through(using, client_lib, call_count):  # pragma: nocover
         assert response.json()["json"] == {"foo": "bar"}
 
         assert respx_mock.calls.last.request.url == url
-        assert respx_mock.calls.last.response == None  # noqa: E711
+        assert respx_mock.calls.last.has_response is False
 
         assert route.call_count == call_count
         assert respx_mock.calls.call_count == call_count

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -37,7 +37,7 @@ def test_remote_pass_through(using, client_lib, call_count):  # pragma: nocover
         assert response.json()["json"] == {"foo": "bar"}
 
         assert respx_mock.calls.last.request.url == url
-        assert respx_mock.calls.last.response is None
+        assert respx_mock.calls.last.response == None  # noqa: E711
 
         assert route.call_count == call_count
         assert respx_mock.calls.call_count == call_count

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -175,7 +175,7 @@ def test_mod_response():
     assert resolved.route is route3
 
     with pytest.raises(TypeError, match="Route can only"):
-        router.route() % []
+        router.route() % []  # type: ignore[operator]
 
 
 @pytest.mark.asyncio
@@ -205,7 +205,7 @@ def test_side_effect_no_match():
     request = httpx.Request("GET", "https://foo.bar/baz/")
     response = router.handler(request)
     assert response.status_code == 204
-    assert response.request.respx_was_here is True
+    assert response.request.respx_was_here is True  # type: ignore[attr-defined]
 
 
 def test_side_effect_with_route_kwarg():

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -523,3 +523,9 @@ def test_routelist__replaces_same_name_other_pattern_other_name():
     routes.add(foobar2, name="foobar")
     assert list(routes) == [foobar2]
     assert routes["foobar"] is foobar1
+
+
+def test_routelist__unable_to_slice_assign():
+    routes = RouteList()
+    with pytest.raises(TypeError, match="slice assign"):
+        routes[0:1] = routes

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -387,12 +387,12 @@ def test_rollback():
 
     assert len(router.routes) == 1
     assert router.calls.call_count == 0
-    assert route.return_value is None
+    assert route.return_value == None  # noqa: E711
 
     router.rollback()  # Empty initial state
 
     assert len(router.routes) == 0
-    assert route.return_value is None
+    assert route.return_value == None  # noqa: E711
 
     # Idempotent
     route.rollback()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -29,11 +29,13 @@ async def test_empty_router__auto_mocked():
     resolved = router.resolve(request)
 
     assert resolved.route is None
+    assert isinstance(resolved.response, httpx.Response)
     assert resolved.response.status_code == 200
 
     resolved = await router.aresolve(request)
 
     assert resolved.route is None
+    assert isinstance(resolved.response, httpx.Response)
     assert resolved.response.status_code == 200
 
 
@@ -62,6 +64,7 @@ def test_resolve(args, kwargs, expected):
     resolved = router.resolve(request)
 
     assert bool(resolved.route is route) is expected
+    assert isinstance(resolved.response, httpx.Response)
     if expected:
         assert bool(resolved.response.status_code == 201) is expected
     else:
@@ -82,6 +85,7 @@ def test_pass_through():
     route.pass_through(False)
     resolved = router.resolve(request)
 
+    assert resolved.route is not None
     assert resolved.route is route
     assert not resolved.route.is_pass_through
     assert resolved.response is not None
@@ -106,6 +110,7 @@ def test_base_url(url, lookups, expected):
     resolved = router.resolve(request)
 
     assert bool(resolved.route is route) is expected
+    assert isinstance(resolved.response, httpx.Response)
     if expected:
         assert bool(resolved.response.status_code == 201) is expected
     else:
@@ -151,17 +156,20 @@ def test_mod_response():
 
     request = httpx.Request("GET", "https://foo.bar/baz/")
     resolved = router.resolve(request)
+    assert isinstance(resolved.response, httpx.Response)
     assert resolved.response.status_code == 404
     assert resolved.route is route1b
     assert route1a is route1b
 
     request = httpx.Request("GET", "https://foo.bar/")
     resolved = router.resolve(request)
+    assert isinstance(resolved.response, httpx.Response)
     assert resolved.response.status_code == 201
     assert resolved.route is route2
 
     request = httpx.Request("POST", "https://fox.zoo/")
     resolved = router.resolve(request)
+    assert isinstance(resolved.response, httpx.Response)
     assert resolved.response.status_code == 401
     assert resolved.response.json() == {"error": "x"}
     assert resolved.route is route3

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -18,7 +18,7 @@ async def test_named_route():
 
 
 @respx.mock
-async def backend_test(backend):
+async def backend_test():
     url = "https://foo.bar/1/"
     respx.get(re.compile("https://some.thing"))
     respx.delete("https://some.thing")
@@ -93,19 +93,14 @@ async def backend_test(backend):
 def test_asyncio():
     import asyncio
 
-    from httpcore.backends.asyncio import AsyncIOBackend
-
-    backend = AsyncIOBackend()  # TODO: Why instantiate a backend?
     loop = asyncio.new_event_loop()
     try:
-        loop.run_until_complete(backend_test(backend))
+        loop.run_until_complete(backend_test())
     finally:
         loop.close()
 
 
 def test_trio():  # pragma: nocover
     import trio
-    from httpcore.backends.trio import TrioBackend
 
-    backend = TrioBackend()  # TODO: Why instantiate a backend?
-    trio.run(backend_test, backend)
+    trio.run(backend_test)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -26,7 +26,7 @@ async def backend_test():
     foobar1 = respx.get(url, name="get_foobar") % dict(status_code=202, text="get")
     foobar2 = respx.delete(url, name="del_foobar") % dict(text="del")
 
-    assert foobar1.called is False
+    assert foobar1.called == False  # noqa: E712
     assert foobar1.call_count == len(foobar1.calls)
     assert foobar1.call_count == 0
     with pytest.raises(IndexError):
@@ -44,8 +44,8 @@ async def backend_test():
         get_response = await client.get(url)
         del_response = await client.delete(url)
 
-    assert foobar1.called is True
-    assert foobar2.called is True
+    assert foobar1.called == True  # noqa: E712
+    assert foobar2.called == True  # noqa: E712
     assert foobar1.call_count == 1
     assert foobar2.call_count == 1
     assert foobar1.calls.call_count == 1

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -29,7 +29,8 @@ async def backend_test(backend):
     assert foobar1.called is False
     assert foobar1.call_count == len(foobar1.calls)
     assert foobar1.call_count == 0
-    assert foobar1.calls.last is None
+    with pytest.raises(IndexError):
+        foobar1.calls.last
     assert respx.calls.call_count == len(respx.calls)
     assert respx.calls.call_count == 0
 


### PR DESCRIPTION
- Add python `3.11` to nox test ssession
- Runs `mypy` on both tests and respx
- Add `Call.has_response` helper
- Changes `Call.response` to raise instead of being optional
- Changes `CallList.last` to raise instead of being optional
- Changes `M()`, and `Route.pattern`, to not be optional by introducing a `Noop` pattern
- Correctly type hint side effects