### PR TITLE
Bump autoflake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,8 @@ repos:
         args:
           - --py37-plus
           - --keep-runtime-typing
-  - repo: https://github.com/myint/autoflake
-    rev: v1.5.3
+  - repo: https://github.com/pycqa/autoflake
+    rev: v1.6.1
     hooks:
       - id: autoflake
         args:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -345,7 +345,7 @@ async def test_request_callback(client):
         assert response.text == "hello lundberg"
 
         respx_mock.get("https://ham.spam/").mock(
-            side_effect=lambda req: "invalid"  # type: ignore[arg-type,return-value]
+            side_effect=lambda req: "invalid"  # type: ignore[arg-type]
         )
 
         def _callback(request):


### PR DESCRIPTION
I happened to notice usage of `myint/autoflake` which is stale, pre-commit won't autoupdate anymore because the project (seems to have) moved to `pycqa/autoflake` :) 