### PR TITLE
Enhance assertion output for `assert_all_called`

### DIFF
--- a/respx/models.py
+++ b/respx/models.py
@@ -510,10 +510,6 @@ class AllMockedAssertionError(AssertionError):
     pass
 
 
-class AllCalledAssertionError(AssertionError):
-    pass
-
-
 class SideEffectError(Exception):
     def __init__(self, route: Route, origin: Exception) -> None:
         self.route = route

--- a/respx/router.py
+++ b/respx/router.py
@@ -21,7 +21,6 @@ import httpx
 
 from .mocks import Mocker
 from .models import (
-    AllCalledAssertionError,
     AllMockedAssertionError,
     CallList,
     PassThrough,
@@ -99,8 +98,8 @@ class Router:
             route.reset()
 
     def assert_all_called(self) -> None:
-        if any(not route.called for route in self.routes):
-            raise AllCalledAssertionError("RESPX: some routes were not called!")
+        not_called_routes = [route for route in self.routes if not route.called]
+        assert not_called_routes == [], "RESPX: some routes were not called!"
 
     def __getitem__(self, name: str) -> Route:
         return self.routes[name]

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -7,7 +7,7 @@ import pytest
 import respx
 from respx import ASGIHandler, WSGIHandler
 from respx.mocks import Mocker
-from respx.models import AllCalledAssertionError, AllMockedAssertionError
+from respx.models import AllMockedAssertionError
 from respx.router import MockRouter
 
 
@@ -405,7 +405,11 @@ async def test_start_stop(client):
 @pytest.mark.parametrize(
     ("assert_all_called", "do_post", "raises"),
     [
-        (True, False, pytest.raises(AllCalledAssertionError)),
+        (
+            True,
+            False,
+            pytest.raises(AssertionError, match="some routes were not called"),
+        ),
         (True, True, does_not_raise()),
         (False, True, does_not_raise()),
         (False, False, does_not_raise()),

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -3,7 +3,7 @@ import warnings
 import httpx
 import pytest
 
-from respx.models import AllCalledAssertionError, PassThrough
+from respx.models import PassThrough
 from respx.router import Router
 from respx.transports import MockTransport
 
@@ -57,7 +57,9 @@ async def test_transport_assertions():
         transport = MockTransport(router=router)
         assert len(w) == 1
 
-    with pytest.raises(AllCalledAssertionError, match="not called"):  # noqa [PT012]
+    with pytest.raises(  # noqa [PT012]
+        AssertionError, match="some routes were not called"
+    ):
         async with httpx.AsyncClient(transport=transport) as client:
             response = await client.get(url)
             assert response.status_code == 404


### PR DESCRIPTION
When AllCalledAssertionError is raised its hard to guess which route got
called and which routes didn't get called.

This change aims to provide more details by listing not called routes
and by leveraging the __repr__ of route object.
