### PR TITLE
Adjust fake ipv6 in tests to follow specification

### DIFF
--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -280,9 +280,9 @@ def test_params_pattern_hash():
         (Lookup.STARTS_WITH, "http://a.b/baz/", {}, "https://a.b/baz/", False),
         (
             Lookup.EQUAL,
-            (b"https", b"fake:ipv6", None, b""),
+            (b"https", b"FE80::1", None, b""),
             {},
-            "https://[fake:ipv6]",
+            "https://[FE80::1]",
             True,
         ),
     ],


### PR DESCRIPTION
Makes the testsuite pass with httpx 0.24 (which otherwise fails on verification as the previous value didn't use eg. :: or hex chars)

I'd used ipv6 for local, not sure if it has any unwanted implications?