### PR TITLE
Fix matching request data when files are provided

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -309,7 +309,7 @@ respx.post("https://example.org/", content__contains="bar")
 ```
 
 ### Data
-Matches request *form data*, using [eq](#eq) as default lookup.
+Matches request *form data*, excluding files, using [eq](#eq) as default lookup.
 > Key: `data`  
 > Lookups: [eq](#eq), [contains](#contains)
 ``` python

--- a/docs/api.md
+++ b/docs/api.md
@@ -311,7 +311,7 @@ respx.post("https://example.org/", content__contains="bar")
 ### Data
 Matches request *form data*, using [eq](#eq) as default lookup.
 > Key: `data`  
-> Lookups: [eq](#eq)
+> Lookups: [eq](#eq), [contains](#contains)
 ``` python
 respx.post("https://example.org/", data={"foo": "bar"})
 ```

--- a/respx/patterns.py
+++ b/respx/patterns.py
@@ -25,6 +25,8 @@ from urllib.parse import urljoin
 
 import httpx
 
+from respx.utils import MultiItems, decode_data
+
 from .types import (
     URL as RawURL,
     CookieTypes,
@@ -536,14 +538,16 @@ class JSON(ContentMixin, PathPattern):
         return jsonlib.dumps(value, sort_keys=True)
 
 
-class Data(ContentMixin, Pattern):
-    lookups = (Lookup.EQUAL,)
+class Data(MultiItemsMixin, Pattern):
+    lookups = (Lookup.EQUAL, Lookup.CONTAINS)
     key = "data"
-    value: bytes
+    value: MultiItems
 
-    def clean(self, value: Dict) -> bytes:
-        request = httpx.Request("POST", "/", data=value)
-        data = request.read()
+    def clean(self, value: Dict) -> MultiItems:
+        return MultiItems(value)
+
+    def parse(self, request: httpx.Request) -> Any:
+        data, _ = decode_data(request)
         return data
 
 

--- a/respx/utils.py
+++ b/respx/utils.py
@@ -1,0 +1,72 @@
+import email
+from email.message import Message
+from typing import Any, List, Tuple, cast
+from urllib.parse import parse_qsl
+
+import httpx
+
+
+class MultiItems(dict):
+    def get_list(self, key: str) -> List[str]:
+        try:
+            return [self[key]]
+        except KeyError:  # pragma: no cover
+            return []
+
+    def multi_items(self) -> List[Tuple[str, str]]:
+        return list(self.items())
+
+
+def _parse_multipart_form_data(
+    content: bytes, *, content_type: str, encoding: str
+) -> Tuple[MultiItems, List[Any]]:
+    form_data = b"\r\n".join(
+        (
+            b"MIME-Version: 1.0",
+            b"Content-Type: " + content_type.encode(encoding),
+            b"\r\n" + content,
+        )
+    )
+    data = MultiItems()
+    files: List[Any] = []
+    for payload in email.message_from_bytes(form_data).get_payload():
+        payload = cast(Message, payload)
+        filename = payload.get_filename()
+        if payload.get_content_maintype() == "text" and filename is None:
+            # Text field
+            key = payload.get_param("name", header="Content-Disposition")
+            value = payload.get_payload(decode=True)
+            assert isinstance(value, bytes)
+            data[key] = value.decode(payload.get_content_charset() or "utf-8")
+        else:
+            # TODO: Implement parsing file fields
+            continue  # pragma: no cover
+
+    return data, files
+
+
+def _parse_urlencoded_data(content: bytes, *, encoding: str) -> MultiItems:
+    return MultiItems(
+        (key, value)
+        for key, value in parse_qsl(content.decode(encoding), keep_blank_values=True)
+    )
+
+
+def decode_data(request: httpx.Request) -> Tuple[MultiItems, List]:
+    content = request.read()
+    content_type = request.headers.get("Content-Type", "")
+
+    if content_type.startswith("multipart/form-data"):
+        data, files = _parse_multipart_form_data(
+            content,
+            content_type=content_type,
+            encoding=request.headers.encoding,
+        )
+    else:
+        data = _parse_urlencoded_data(
+            content,
+            encoding=request.headers.encoding,
+        )
+        files = []
+
+    return data, files

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -263,6 +263,15 @@ def test_json_post_body():
         assert get_route.called
 
 
+def test_data_post_body():
+    with respx.mock:
+        url = "https://foo.bar/"
+        route = respx.post(url, data={"foo": "bar"}) % 201
+        response = httpx.post(url, data={"foo": "bar"}, files={"file": b"..."})
+        assert response.status_code == 201
+        assert route.called
+
+
 async def test_raising_content(client):
     async with MockRouter() as respx_mock:
         url = "https://foo.bar/"


### PR DESCRIPTION
When posting data with `httpx` along with files, the request body gets encoded as multipart form-data. This PR adds support for matching request data even if files are included in the actual request.

As a bonus feature, the [data](https://lundberg.github.io/respx/api/#data) pattern gets support for the [contains](https://lundberg.github.io/respx/api/#contains) lookup. The *eq* lookup is kept as default for now, but will probably be changed to *contains* in the future.

Fixes #251 