### PR TITLE
Add `SetCookie` utility

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -202,18 +202,14 @@ Shortcut for creating and mocking a `HTTPX` [Response](#response).
 
 ## SetCookie
 
-A utility to render a `Set-Cookie` header value. See route [respond](#respond) shortcut for alternative use.
+A utility to render a `("Set-Cookie", <cookie header value>)` tuple. See route [respond](#respond) shortcut for alternative use.
 
 > <code>respx.<strong>SetCookie</strong>(*name, value, path=None, domain=None, expires=None, max_age=None, http_only=False, same_site=None, secure=False, partitioned=False*)</strong></code>
-
-### .header
-
-Returns a `("Set-Cookie", <cookie header value>)` name/value header pair.
 
 ``` python
 import respx
 respx.post("https://example.org/").mock(
-    return_value=httpx.Response(200, headers=[SetCookie("foo", "bar").header])
+    return_value=httpx.Response(200, headers=[SetCookie("foo", "bar")])
 )
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -133,14 +133,16 @@ Setter for the [side effect](guide.md#mock-with-a-side-effect) to trigger.
 
 Shortcut for creating and mocking a `HTTPX` [Response](#response).
 
-> <code>route.<strong>respond</strong>(*status_code=200, headers=None, content=None, text=None, html=None, json=None, stream=None*)</strong></code>
+> <code>route.<strong>respond</strong>(*status_code=200, headers=None, cookies=None, content=None, text=None, html=None, json=None, stream=None, content_type=None*)</strong></code>
 >
 > **Parameters:**
 >
 > * **status_code** - *(optional) int - default: `200`*  
 >   Response status code to mock.
-> * **headers** - *(optional) dict*  
+> * **headers** - *(optional) dict | sequence of pairs*  
 >   Response headers to mock.
+> * **cookies** - *(optional) dict | sequence of pairs | sequence of `SetCookie`*  
+>   Response cookies to mock as `Set-Cookie` headers. See [SetCookie](#setcookie).
 > * **content** - *(optional) bytes | str | iterable bytes*  
 >   Response raw content to mock.
 > * **text** - *(optional) str*  
@@ -151,6 +153,8 @@ Shortcut for creating and mocking a `HTTPX` [Response](#response).
 >   Response *JSON* content to mock, with automatic content-type header added.
 > * **stream** - *(optional) Iterable[bytes]*  
 >   Response *stream* to mock.
+> * **content_type** - *(optional) str*  
+>   Response `Content-Type` header to mock.
 >
 > **Returns:** `Route`
 
@@ -190,6 +194,28 @@ Shortcut for creating and mocking a `HTTPX` [Response](#response).
 >   JSON content, with automatic content-type header added.
 > * **stream** - *(optional) Iterable[bytes]*  
 >   Content *stream*.
+
+!!! tip "Cookies"
+    Use [respx.SetCookie(...)](#setcookie) to produce `Set-Cookie` headers.
+
+---
+
+## SetCookie
+
+A utility to render a `Set-Cookie` header value. See route [respond](#respond) shortcut for alternative use.
+
+> <code>respx.<strong>SetCookie</strong>(*name, value, path=None, domain=None, expires=None, max_age=None, http_only=False, same_site=None, secure=False, partitioned=False*)</strong></code>
+
+### .header
+
+Returns a `("Set-Cookie", <cookie header value>)` name/value header pair.
+
+``` python
+import respx
+respx.post("https://example.org/").mock(
+    return_value=httpx.Response(200, headers=[SetCookie("foo", "bar").header])
+)
+```
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -139,11 +139,11 @@ Shortcut for creating and mocking a `HTTPX` [Response](#response).
 >
 > * **status_code** - *(optional) int - default: `200`*  
 >   Response status code to mock.
-> * **headers** - *(optional) dict | sequence of pairs*  
+> * **headers** - *(optional) dict | Sequence[tuple[str, str]]*  
 >   Response headers to mock.
-> * **cookies** - *(optional) dict | sequence of pairs | sequence of `SetCookie`*  
+> * **cookies** - *(optional) dict | Sequence[tuple[str, str]] | Sequence[SetCookie]*  
 >   Response cookies to mock as `Set-Cookie` headers. See [SetCookie](#setcookie).
-> * **content** - *(optional) bytes | str | iterable bytes*  
+> * **content** - *(optional) bytes | str | Iterable[bytes]*  
 >   Response raw content to mock.
 > * **text** - *(optional) str*  
 >   Response *text* content to mock, with automatic content-type header added.

--- a/respx/__init__.py
+++ b/respx/__init__.py
@@ -2,6 +2,7 @@ from .__version__ import __version__
 from .handlers import ASGIHandler, WSGIHandler
 from .models import MockResponse, Route
 from .router import MockRouter, Router
+from .utils import SetCookie
 
 from .api import (  # isort:skip
     mock,
@@ -24,6 +25,7 @@ from .api import (  # isort:skip
     options,
 )
 
+
 __all__ = [
     "__version__",
     "MockResponse",
@@ -32,6 +34,7 @@ __all__ = [
     "WSGIHandler",
     "Router",
     "Route",
+    "SetCookie",
     "mock",
     "routes",
     "calls",

--- a/respx/models.py
+++ b/respx/models.py
@@ -16,10 +16,13 @@ from warnings import warn
 
 import httpx
 
+from respx.utils import SetCookie
+
 from .patterns import M, Pattern
 from .types import (
     CallableSideEffect,
     Content,
+    CookieTypes,
     HeaderTypes,
     ResolvedResponseTypes,
     RouteResultTypes,
@@ -90,6 +93,7 @@ class MockResponse(httpx.Response):
         content: Optional[Content] = None,
         content_type: Optional[str] = None,
         http_version: Optional[str] = None,
+        cookies: Optional[Union[CookieTypes, Sequence[SetCookie]]] = None,
         **kwargs: Any,
     ) -> None:
         if not isinstance(content, (str, bytes)) and (
@@ -109,6 +113,21 @@ class MockResponse(httpx.Response):
 
         if content_type:
             self.headers["Content-Type"] = content_type
+
+        if cookies:
+            if isinstance(cookies, dict):
+                cookies = tuple(cookies.items())
+            self.headers = httpx.Headers(
+                (
+                    *self.headers.multi_items(),
+                    *(
+                        cookie.header
+                        if isinstance(cookie, SetCookie)
+                        else SetCookie(*cookie).header
+                        for cookie in cookies
+                    ),
+                )
+            )
 
 
 class Route:
@@ -256,6 +275,7 @@ class Route:
         status_code: int = 200,
         *,
         headers: Optional[HeaderTypes] = None,
+        cookies: Optional[Union[CookieTypes, Sequence[SetCookie]]] = None,
         content: Optional[Content] = None,
         text: Optional[str] = None,
         html: Optional[str] = None,
@@ -268,6 +288,7 @@ class Route:
         response = MockResponse(
             status_code,
             headers=headers,
+            cookies=cookies,
             content=content,
             text=text,
             html=html,

--- a/respx/models.py
+++ b/respx/models.py
@@ -121,9 +121,7 @@ class MockResponse(httpx.Response):
                 (
                     *self.headers.multi_items(),
                     *(
-                        cookie.header
-                        if isinstance(cookie, SetCookie)
-                        else SetCookie(*cookie).header
+                        cookie if isinstance(cookie, SetCookie) else SetCookie(*cookie)
                         for cookie in cookies
                     ),
                 )

--- a/respx/utils.py
+++ b/respx/utils.py
@@ -82,10 +82,15 @@ def decode_data(request: httpx.Request) -> Tuple[MultiItems, MultiItems]:
 Self = TypeVar("Self", bound="SetCookie")
 
 
-class SetCookie(NamedTuple("SetCookieBase", [("key", str), ("value", str)])):
-    key: str
-    value: str
-
+class SetCookie(
+    NamedTuple(
+        "SetCookie",
+        [
+            ("header_name", Literal["Set-Cookie"]),
+            ("header_value", str),
+        ],
+    )
+):
     def __new__(
         cls: Type[Self],
         name: str,

--- a/respx/utils.py
+++ b/respx/utils.py
@@ -1,7 +1,7 @@
 import email
 from datetime import datetime
 from email.message import Message
-from typing import Dict, List, Optional, Tuple, Type, TypeVar, Union, cast
+from typing import Dict, List, NamedTuple, Optional, Tuple, Type, TypeVar, Union, cast
 from urllib.parse import parse_qsl
 
 try:
@@ -82,8 +82,9 @@ def decode_data(request: httpx.Request) -> Tuple[MultiItems, MultiItems]:
 Self = TypeVar("Self", bound="SetCookie")
 
 
-class SetCookie(str):
-    __slots__ = ()
+class SetCookie(NamedTuple("SetCookieBase", [("key", str), ("value", str)])):
+    key: str
+    value: str
 
     def __new__(
         cls: Type[Self],
@@ -128,9 +129,5 @@ class SetCookie(str):
             _name if _value is True else f"{_name}={_value}"
             for _name, _value in attrs.items()
         )
-        self = super().__new__(cls, string)
+        self = super().__new__(cls, "Set-Cookie", string)
         return self
-
-    @property
-    def header(self) -> Tuple[Literal["Set-Cookie"], str]:
-        return "Set-Cookie", self

--- a/respx/utils.py
+++ b/respx/utils.py
@@ -1,7 +1,13 @@
 import email
+from datetime import datetime
 from email.message import Message
-from typing import List, Tuple, cast
+from typing import Dict, List, Optional, Tuple, Type, TypeVar, Union, cast
 from urllib.parse import parse_qsl
+
+try:
+    from typing import Literal  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover
+    from typing_extensions import Literal
 
 import httpx
 
@@ -71,3 +77,60 @@ def decode_data(request: httpx.Request) -> Tuple[MultiItems, MultiItems]:
         files = MultiItems()
 
     return data, files
+
+
+Self = TypeVar("Self", bound="SetCookie")
+
+
+class SetCookie(str):
+    __slots__ = ()
+
+    def __new__(
+        cls: Type[Self],
+        name: str,
+        value: str,
+        *,
+        path: Optional[str] = None,
+        domain: Optional[str] = None,
+        expires: Optional[Union[str, datetime]] = None,
+        max_age: Optional[int] = None,
+        http_only: bool = False,
+        same_site: Optional[Literal["Strict", "Lax", "None"]] = None,
+        secure: bool = False,
+        partitioned: bool = False,
+    ) -> Self:
+        """
+        https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#syntax
+        """
+        attrs: Dict[str, Union[str, bool]] = {name: value}
+        if path is not None:
+            attrs["Path"] = path
+        if domain is not None:
+            attrs["Domain"] = domain
+        if expires is not None:
+            if isinstance(expires, datetime):  # pragma: no branch
+                expires = expires.strftime("%a, %d %b %Y %H:%M:%S GMT")
+            attrs["Expires"] = expires
+        if max_age is not None:
+            attrs["Max-Age"] = str(max_age)
+        if http_only:
+            attrs["HttpOnly"] = True
+        if same_site is not None:
+            attrs["SameSite"] = same_site
+            if same_site == "None":  # pragma: no branch
+                secure = True
+        if secure:
+            attrs["Secure"] = True
+        if partitioned:
+            attrs["Partitioned"] = True
+
+        string = "; ".join(
+            _name if _value is True else f"{_name}={_value}"
+            for _name, _value in attrs.items()
+        )
+        self = super().__new__(cls, string)
+        return self
+
+    @property
+    def header(self) -> Tuple[Literal["Set-Cookie"], str]:
+        return "Set-Cookie", self

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -564,7 +564,7 @@ def test_respond():
             route.respond(content=Exception())  # type: ignore[arg-type]
 
 
-def test_respond_with_cookies():
+def test_can_respond_with_cookies():
     with respx.mock:
         route = respx.get("https://foo.bar/").respond(
             json={}, headers={"X-Foo": "bar"}, cookies={"foo": "bar", "ham": "spam"}
@@ -589,7 +589,7 @@ def test_respond_with_cookies():
         assert response.cookies["foo"] == "bar"
 
 
-def test_mock_response_with_cookies():
+def test_can_mock_response_with_set_cookie_headers():
     request = httpx.Request("GET", "https://example.com/")
     response = httpx.Response(
         200,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -594,8 +594,8 @@ def test_mock_response_with_cookies():
     response = httpx.Response(
         200,
         headers=[
-            respx.SetCookie("foo", value="bar").header,
-            respx.SetCookie("ham", value="spam").header,
+            respx.SetCookie("foo", value="bar"),
+            respx.SetCookie("ham", value="spam"),
         ],
         request=request,
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,30 +3,31 @@ from datetime import datetime, timezone
 from respx.utils import SetCookie
 
 
-def test_set_cookie_header():
-    expires = datetime.fromtimestamp(0, tz=timezone.utc)
-    cookie = SetCookie(
-        "foo",
-        value="bar",
-        path="/",
-        domain=".example.com",
-        expires=expires,
-        max_age=44,
-        http_only=True,
-        same_site="None",
-        partitioned=True,
-    )
-    assert cookie == (
-        "Set-Cookie",
-        (
-            "foo=bar; "
-            "Path=/; "
-            "Domain=.example.com; "
-            "Expires=Thu, 01 Jan 1970 00:00:00 GMT; "
-            "Max-Age=44; "
-            "HttpOnly; "
-            "SameSite=None; "
-            "Secure; "
-            "Partitioned"
-        ),
-    )
+class TestSetCookie:
+    def test_can_render_all_attributes(self) -> None:
+        expires = datetime.fromtimestamp(0, tz=timezone.utc)
+        cookie = SetCookie(
+            "foo",
+            value="bar",
+            path="/",
+            domain=".example.com",
+            expires=expires,
+            max_age=44,
+            http_only=True,
+            same_site="None",
+            partitioned=True,
+        )
+        assert cookie == (
+            "Set-Cookie",
+            (
+                "foo=bar; "
+                "Path=/; "
+                "Domain=.example.com; "
+                "Expires=Thu, 01 Jan 1970 00:00:00 GMT; "
+                "Max-Age=44; "
+                "HttpOnly; "
+                "SameSite=None; "
+                "Secure; "
+                "Partitioned"
+            ),
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,7 @@ def test_set_cookie_header():
         same_site="None",
         partitioned=True,
     )
-    assert cookie.header == (
+    assert cookie == (
         "Set-Cookie",
         (
             "foo=bar; "

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timezone
+
+from respx.utils import SetCookie
+
+
+def test_set_cookie_header():
+    expires = datetime.fromtimestamp(0, tz=timezone.utc)
+    cookie = SetCookie(
+        "foo",
+        value="bar",
+        path="/",
+        domain=".example.com",
+        expires=expires,
+        max_age=44,
+        http_only=True,
+        same_site="None",
+        partitioned=True,
+    )
+    assert cookie.header == (
+        "Set-Cookie",
+        (
+            "foo=bar; "
+            "Path=/; "
+            "Domain=.example.com; "
+            "Expires=Thu, 01 Jan 1970 00:00:00 GMT; "
+            "Max-Age=44; "
+            "HttpOnly; "
+            "SameSite=None; "
+            "Secure; "
+            "Partitioned"
+        ),
+    )


### PR DESCRIPTION
Adds a `respx.SetCookie` utility that can be used for easier mocking of response `Set-Cookie` headers.

The `route.respond(...)` helper is also enhanced with a `cookies` kwarg that supports `dict[str, str]`, `Sequence[tuple[str, str]]` or `Sequence[SetCookie]`.

Example usage via headers:
```py
respx.post("https://example.com/").mock(
    return_value=httpx.Response(200, headers=[SetCookie("foo", "bar")])
)
```
.. or by using respond ..
```py
respx.post("https://example.com/").respond(cookies={"foo": "bar"})
respx.post("https://example.com/").respond(cookies=[SetCookie("foo", "bar", path="/", ...)])
```

Fixes #249 