### PR TITLE
Update CI test to not fail fast and cancel workflows on same HEAD ref

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,20 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   FORCE_COLOR: 1
+  PYTHONUNBUFFERED: "1"
 
 jobs:
   test:
     name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       max-parallel: 4
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]


### PR DESCRIPTION
A bit nicer to see everything that's failing when pushing to GitHub