### PR TITLE
Fix compatibility with httpx 0.28.0

### DIFF
--- a/respx/mocks.py
+++ b/respx/mocks.py
@@ -297,6 +297,11 @@ class HTTPCoreMocker(AbstractRequestMocker):
         Create a `HTTPX` request from transport request arg.
         """
         request = kwargs["request"]
+        method = (
+            request.method.decode("ascii").upper()
+            if isinstance(request.method, bytes)
+            else request.method.upper()
+        )
         raw_url = (
             request.url.scheme,
             request.url.host,
@@ -304,7 +309,7 @@ class HTTPCoreMocker(AbstractRequestMocker):
             request.url.target,
         )
         return httpx.Request(
-            request.method,
+            method,
             parse_url(raw_url),
             headers=request.headers,
             stream=request.stream,

--- a/respx/mocks.py
+++ b/respx/mocks.py
@@ -298,9 +298,9 @@ class HTTPCoreMocker(AbstractRequestMocker):
         """
         request = kwargs["request"]
         method = (
-            request.method.decode("ascii").upper()
+            request.method.decode("ascii")
             if isinstance(request.method, bytes)
-            else request.method.upper()
+            else request.method
         )
         raw_url = (
             request.url.scheme,

--- a/respx/patterns.py
+++ b/respx/patterns.py
@@ -16,14 +16,12 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Pattern as RegexPattern,
     Sequence,
     Set,
     Tuple,
     Type,
     Union,
-)
-from typing import (
-    Pattern as RegexPattern,
 )
 from unittest.mock import ANY
 from urllib.parse import urljoin
@@ -34,8 +32,6 @@ from respx.utils import MultiItems, decode_data
 
 from .types import (
     URL as RawURL,
-)
-from .types import (
     CookieTypes,
     FileTypes,
     HeaderTypes,

--- a/respx/patterns.py
+++ b/respx/patterns.py
@@ -16,12 +16,14 @@ from typing import (
     List,
     Mapping,
     Optional,
-    Pattern as RegexPattern,
     Sequence,
     Set,
     Tuple,
     Type,
     Union,
+)
+from typing import (
+    Pattern as RegexPattern,
 )
 from unittest.mock import ANY
 from urllib.parse import urljoin
@@ -32,6 +34,8 @@ from respx.utils import MultiItems, decode_data
 
 from .types import (
     URL as RawURL,
+)
+from .types import (
     CookieTypes,
     FileTypes,
     HeaderTypes,

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     python_requires=">=3.8",
-    install_requires=["httpx>=0.25.0,<0.28.0"],
+    install_requires=["httpx>=0.25.0"],
 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -214,7 +214,7 @@ async def test_content_variants(client, key, value, expected_content_type):
             {"X-Foo": "bar"},
             {
                 "Content-Type": "application/json",
-                "Content-Length": "14",
+                "Content-Length": "13",
                 "X-Foo": "bar",
             },
         ),
@@ -223,7 +223,7 @@ async def test_content_variants(client, key, value, expected_content_type):
             {"Content-Type": "application/json; charset=utf-8", "X-Foo": "bar"},
             {
                 "Content-Type": "application/json; charset=utf-8",
-                "Content-Length": "14",
+                "Content-Length": "13",
                 "X-Foo": "bar",
             },
         ),
@@ -322,19 +322,19 @@ async def test_callable_content(client):
         assert request.called is True
         assert async_response.status_code == 200
         assert async_response.text == "hello world."
-        assert request.calls[-1][0].content == b'{"x": "."}'
+        assert request.calls[-1][0].content == b'{"x":"."}'
 
         respx_mock.reset()
         sync_response = httpx.post("https://foo.bar/jonas/", json={"x": "!"})
         assert request.called is True
         assert sync_response.status_code == 200
         assert sync_response.text == "hello jonas!"
-        assert request.calls[-1][0].content == b'{"x": "!"}'
+        assert request.calls[-1][0].content == b'{"x":"!"}'
 
 
 async def test_request_callback(client):
     def callback(request, name):
-        if request.url.host == "foo.bar" and request.content == b'{"foo": "bar"}':
+        if request.url.host == "foo.bar" and request.content == b'{"foo":"bar"}':
             return respx.MockResponse(
                 202,
                 headers={"X-Foo": "bar"},

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -476,15 +476,13 @@ def test_add_remove_targets():
 async def test_proxies():
     with respx.mock:
         respx.get("https://foo.bar/") % dict(json={"foo": "bar"})
-        with httpx.Client(proxies={"https://": "https://1.1.1.1:1"}) as client:
+        with httpx.Client(proxy="https://1.1.1.1:1") as client:
             response = client.get("https://foo.bar/")
         assert response.json() == {"foo": "bar"}
 
     async with respx.mock:
         respx.get("https://foo.bar/") % dict(json={"foo": "bar"})
-        async with httpx.AsyncClient(
-            proxies={"https://": "https://1.1.1.1:1"}
-        ) as client:
+        async with httpx.AsyncClient(proxy="https://1.1.1.1:1") as client:
             response = await client.get("https://foo.bar/")
         assert response.json() == {"foo": "bar"}
 


### PR DESCRIPTION
Prior to httpx version `0.28.0`, request methods were implicitly converted from bytes to strings. [In version `0.28.0` that is no longer the case](https://github.com/encode/httpx/commit/66225539796d819b5114ead2fd5e4d61865ab708).

Since httpx request objects expect strings for the method field, and httpcore request objects [enforce bytes](https://github.com/encode/httpcore/blob/master/httpcore/_models.py#L344), I've copied the conversion from bytes to strings from the previous httpx version in to respx.

I didn't add tests because there are no explicit tests on the `to_httpx_request` method, but I can if you'd like.

Fixes #277.