### PR TITLE
Fix possible types for json parameter to Route.respond

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -149,7 +149,7 @@ Shortcut for creating and mocking a `HTTPX` [Response](#response).
 >   Response *text* content to mock, with automatic content-type header added.
 > * **html** - *(optional) str*  
 >   Response *HTML* content to mock, with automatic content-type header added.
-> * **json** - *(optional) str | list | dict*  
+> * **json** - *(optional) str | list | dict | tuple | float*  
 >   Response *JSON* content to mock, with automatic content-type header added.
 > * **stream** - *(optional) Iterable[bytes]*  
 >   Response *stream* to mock.
@@ -190,7 +190,7 @@ Shortcut for creating and mocking a `HTTPX` [Response](#response).
 >   Text content, with automatic content-type header added.
 > * **html** - *(optional) str*  
 >   HTML content, with automatic content-type header added.
-> * **json** - *(optional) str | list | dict*  
+> * **json** - *(optional) str | list | dict | tuple | float*  
 >   JSON content, with automatic content-type header added.
 > * **stream** - *(optional) Iterable[bytes]*  
 >   Content *stream*.

--- a/respx/models.py
+++ b/respx/models.py
@@ -277,7 +277,7 @@ class Route:
         content: Optional[Content] = None,
         text: Optional[str] = None,
         html: Optional[str] = None,
-        json: Optional[Union[str, List, Dict]] = None,
+        json: Optional[Union[str, List, Dict, Tuple, float]] = None,
         stream: Optional[Union[httpx.SyncByteStream, httpx.AsyncByteStream]] = None,
         content_type: Optional[str] = None,
         http_version: Optional[str] = None,


### PR DESCRIPTION
According to the [Python documentation](https://docs.python.org/3/library/json.html#json.JSONEncoder), more than just strings, dicts, and lists can be encoded to JSON.
