### PR TITLE
Fix pass_through with HTTP proxy

### DIFF
--- a/respx/mocks.py
+++ b/respx/mocks.py
@@ -167,10 +167,6 @@ class HTTPXMocker(Mocker):
 
 class AbstractRequestMocker(Mocker):
     @classmethod
-    def _should_bypass(cls, **kwargs) -> bool:
-        return False
-
-    @classmethod
     def mock(cls, spec):
         if spec.__name__ not in cls.target_methods:
             # Prevent mocking mock
@@ -180,8 +176,6 @@ class AbstractRequestMocker(Mocker):
 
         def mock(self, *args, **kwargs):
             kwargs = cls._merge_args_and_kwargs(argspec, args, kwargs)
-            if cls._should_bypass(**kwargs):
-                return spec(self, **kwargs)
             request = cls.to_httpx_request(**kwargs)
             request, kwargs = cls.prepare_sync_request(request, **kwargs)
             response = cls._send_sync_request(
@@ -191,8 +185,6 @@ class AbstractRequestMocker(Mocker):
 
         async def amock(self, *args, **kwargs):
             kwargs = cls._merge_args_and_kwargs(argspec, args, kwargs)
-            if cls._should_bypass(**kwargs):
-                return await spec(self, **kwargs)
             request = cls.to_httpx_request(**kwargs)
             request, kwargs = await cls.prepare_async_request(request, **kwargs)
             response = await cls._send_async_request(
@@ -280,17 +272,6 @@ class HTTPCoreMocker(AbstractRequestMocker):
     target_methods = ["handle_request", "handle_async_request"]
 
     @classmethod
-    def _should_bypass(cls, **kwargs) -> bool:
-        # Bypass CONNECT requests because we cannot mock proxy tunnels:
-        # 1. CONNECT URLs lack a scheme, crashing our URL parser.
-        # 2. Tunnels require a live socket, not a static mock response.
-        request = kwargs.get("request")
-        if request is not None:
-            if request.method in (b"CONNECT", "CONNECT"):
-                return True
-        return False
-
-    @classmethod
     def prepare_sync_request(cls, httpx_request, **kwargs):
         """
         Sync pre-read request body, and update transport request arg.
@@ -321,15 +302,27 @@ class HTTPCoreMocker(AbstractRequestMocker):
             if isinstance(request.method, bytes)
             else request.method
         )
-        raw_url = (
-            request.url.scheme,
-            request.url.host,
-            request.url.port,
-            request.url.target,
-        )
+
+        if method == "CONNECT":
+            # CONNECT uses authority-form targets (host:port) for tunnel
+            # establishment. Build URL from the target so route matching
+            # works on the remote host.
+            target = request.url.target
+            if isinstance(target, bytes):
+                target = target.decode("ascii")
+            url = httpx.URL(f"https://{target}/")
+        else:
+            raw_url = (
+                request.url.scheme,
+                request.url.host,
+                request.url.port,
+                request.url.target,
+            )
+            url = parse_url(raw_url)
+
         return httpx.Request(
             method,
-            parse_url(raw_url),
+            url,
             headers=request.headers,
             stream=request.stream,
             extensions=request.extensions,

--- a/respx/mocks.py
+++ b/respx/mocks.py
@@ -167,6 +167,10 @@ class HTTPXMocker(Mocker):
 
 class AbstractRequestMocker(Mocker):
     @classmethod
+    def _should_bypass(cls, **kwargs) -> bool:
+        return False
+
+    @classmethod
     def mock(cls, spec):
         if spec.__name__ not in cls.target_methods:
             # Prevent mocking mock
@@ -176,6 +180,8 @@ class AbstractRequestMocker(Mocker):
 
         def mock(self, *args, **kwargs):
             kwargs = cls._merge_args_and_kwargs(argspec, args, kwargs)
+            if cls._should_bypass(**kwargs):
+                return spec(self, **kwargs)
             request = cls.to_httpx_request(**kwargs)
             request, kwargs = cls.prepare_sync_request(request, **kwargs)
             response = cls._send_sync_request(
@@ -185,6 +191,8 @@ class AbstractRequestMocker(Mocker):
 
         async def amock(self, *args, **kwargs):
             kwargs = cls._merge_args_and_kwargs(argspec, args, kwargs)
+            if cls._should_bypass(**kwargs):
+                return await spec(self, **kwargs)
             request = cls.to_httpx_request(**kwargs)
             request, kwargs = await cls.prepare_async_request(request, **kwargs)
             response = await cls._send_async_request(
@@ -270,6 +278,17 @@ class HTTPCoreMocker(AbstractRequestMocker):
         "httpcore._async.http_proxy.AsyncHTTPProxy",
     ]
     target_methods = ["handle_request", "handle_async_request"]
+
+    @classmethod
+    def _should_bypass(cls, **kwargs) -> bool:
+        # Bypass CONNECT requests because we cannot mock proxy tunnels:
+        # 1. CONNECT URLs lack a scheme, crashing our URL parser.
+        # 2. Tunnels require a live socket, not a static mock response.
+        request = kwargs.get("request")
+        if request is not None:
+            if request.method in (b"CONNECT", "CONNECT"):
+                return True
+        return False
 
     @classmethod
     def prepare_sync_request(cls, httpx_request, **kwargs):

--- a/respx/mocks.py
+++ b/respx/mocks.py
@@ -302,27 +302,15 @@ class HTTPCoreMocker(AbstractRequestMocker):
             if isinstance(request.method, bytes)
             else request.method
         )
-
-        if method == "CONNECT":
-            # CONNECT uses authority-form targets (host:port) for tunnel
-            # establishment. Build URL from the target so route matching
-            # works on the remote host.
-            target = request.url.target
-            if isinstance(target, bytes):
-                target = target.decode("ascii")
-            url = httpx.URL(f"https://{target}/")
-        else:
-            raw_url = (
-                request.url.scheme,
-                request.url.host,
-                request.url.port,
-                request.url.target,
-            )
-            url = parse_url(raw_url)
-
+        raw_url = (
+            request.url.scheme,
+            request.url.host,
+            request.url.port,
+            request.url.target if method != "CONNECT" else b"/",
+        )
         return httpx.Request(
             method,
-            url,
+            parse_url(raw_url),
             headers=request.headers,
             stream=request.stream,
             extensions=request.extensions,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -422,6 +422,7 @@ async def test_pass_through(client, using, route, expected):
 async def test_pass_through_with_proxy():
     # Sync
     with respx.mock:
+        connect_route = respx.route(method="CONNECT").pass_through()
         route = respx.get("https://foo.bar/").pass_through()
         with mock.patch(
             "socket.create_connection", side_effect=socket.error("test request blocked")
@@ -430,10 +431,12 @@ async def test_pass_through_with_proxy():
                 with httpx.Client(proxy="https://1.1.1.1:1") as client:
                     client.get("https://foo.bar/")
         assert connect.called is True
+        assert connect_route.called is True
         assert route.called is True
 
     # Async
     async with respx.mock:
+        connect_route = respx.route(method="CONNECT").pass_through()
         route = respx.get("https://foo.bar/").pass_through()
         with mock.patch(
             "anyio.connect_tcp",
@@ -443,7 +446,33 @@ async def test_pass_through_with_proxy():
                 async with httpx.AsyncClient(proxy="https://1.1.1.1:1") as client:
                     await client.get("https://foo.bar/")
         assert open_connection.called is True
+        assert connect_route.called is True
         assert route.called is True
+
+
+async def test_mocked_connect_proxy_response():
+    # Sync - mock a 407 Proxy Authentication Required on CONNECT
+    # GET must pass through so the real proxy code sends CONNECT internally.
+    with respx.mock:
+        connect_route = respx.route(method="CONNECT").mock(
+            return_value=httpx.Response(407)
+        )
+        respx.get("https://foo.bar/").pass_through()
+        with pytest.raises(httpx.ProxyError):
+            with httpx.Client(proxy="https://1.1.1.1:1") as client:
+                client.get("https://foo.bar/")
+        assert connect_route.called is True
+
+    # Async - mock a 407 Proxy Authentication Required on CONNECT
+    async with respx.mock:
+        connect_route = respx.route(method="CONNECT").mock(
+            return_value=httpx.Response(407)
+        )
+        respx.get("https://foo.bar/").pass_through()
+        with pytest.raises(httpx.ProxyError):
+            async with httpx.AsyncClient(proxy="https://1.1.1.1:1") as client:
+                await client.get("https://foo.bar/")
+        assert connect_route.called is True
 
 
 @respx.mock

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -419,62 +419,6 @@ async def test_pass_through(client, using, route, expected):
         assert request.is_pass_through is expected
 
 
-async def test_pass_through_with_proxy():
-    # Sync
-    with respx.mock:
-        connect_route = respx.route(method="CONNECT").pass_through()
-        route = respx.get("https://foo.bar/").pass_through()
-        with mock.patch(
-            "socket.create_connection", side_effect=socket.error("test request blocked")
-        ) as connect:
-            with pytest.raises(httpx.NetworkError):
-                with httpx.Client(proxy="https://1.1.1.1:1") as client:
-                    client.get("https://foo.bar/")
-        assert connect.called is True
-        assert connect_route.called is True
-        assert route.called is True
-
-    # Async
-    async with respx.mock:
-        connect_route = respx.route(method="CONNECT").pass_through()
-        route = respx.get("https://foo.bar/").pass_through()
-        with mock.patch(
-            "anyio.connect_tcp",
-            side_effect=ConnectionRefusedError("test request blocked"),
-        ) as open_connection:
-            with pytest.raises(httpx.NetworkError):
-                async with httpx.AsyncClient(proxy="https://1.1.1.1:1") as client:
-                    await client.get("https://foo.bar/")
-        assert open_connection.called is True
-        assert connect_route.called is True
-        assert route.called is True
-
-
-async def test_mocked_connect_proxy_response():
-    # Sync - mock a 407 Proxy Authentication Required on CONNECT
-    # GET must pass through so the real proxy code sends CONNECT internally.
-    with respx.mock:
-        connect_route = respx.route(method="CONNECT").mock(
-            return_value=httpx.Response(407)
-        )
-        respx.get("https://foo.bar/").pass_through()
-        with pytest.raises(httpx.ProxyError):
-            with httpx.Client(proxy="https://1.1.1.1:1") as client:
-                client.get("https://foo.bar/")
-        assert connect_route.called is True
-
-    # Async - mock a 407 Proxy Authentication Required on CONNECT
-    async with respx.mock:
-        connect_route = respx.route(method="CONNECT").mock(
-            return_value=httpx.Response(407)
-        )
-        respx.get("https://foo.bar/").pass_through()
-        with pytest.raises(httpx.ProxyError):
-            async with httpx.AsyncClient(proxy="https://1.1.1.1:1") as client:
-                await client.get("https://foo.bar/")
-        assert connect_route.called is True
-
-
 @respx.mock
 async def test_parallel_requests(client):
     def content(request, page):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -419,6 +419,33 @@ async def test_pass_through(client, using, route, expected):
         assert request.is_pass_through is expected
 
 
+async def test_pass_through_with_proxy():
+    # Sync
+    with respx.mock:
+        route = respx.get("https://foo.bar/").pass_through()
+        with mock.patch(
+            "socket.create_connection", side_effect=socket.error("test request blocked")
+        ) as connect:
+            with pytest.raises(httpx.NetworkError):
+                with httpx.Client(proxy="https://1.1.1.1:1") as client:
+                    client.get("https://foo.bar/")
+        assert connect.called is True
+        assert route.called is True
+
+    # Async
+    async with respx.mock:
+        route = respx.get("https://foo.bar/").pass_through()
+        with mock.patch(
+            "anyio.connect_tcp",
+            side_effect=ConnectionRefusedError("test request blocked"),
+        ) as open_connection:
+            with pytest.raises(httpx.NetworkError):
+                async with httpx.AsyncClient(proxy="https://1.1.1.1:1") as client:
+                    await client.get("https://foo.bar/")
+        assert open_connection.called is True
+        assert route.called is True
+
+
 @respx.mock
 async def test_parallel_requests(client):
     def content(request, page):

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -495,7 +495,7 @@ async def test_proxies(proxy_url):
             "socket.create_connection", side_effect=socket.error("test request blocked")
         ) as connect:
             with httpx.Client(proxy=proxy_url) as client:
-                with pytest.raises(httpx.NetworkError):
+                with pytest.raises(httpx.NetworkError):  # pragma: no branch
                     client.get("https://foo.bar/")
         assert connect.called is True
         assert route.called is True
@@ -508,7 +508,7 @@ async def test_proxies(proxy_url):
             side_effect=ConnectionRefusedError("test request blocked"),
         ) as open_connection:
             async with httpx.AsyncClient(proxy=proxy_url) as client:
-                with pytest.raises(httpx.NetworkError):
+                with pytest.raises(httpx.NetworkError):  # pragma: no branch
                     await client.get("https://foo.bar/")
         assert open_connection.called is True
         assert route.called is True
@@ -523,7 +523,7 @@ async def test_proxies(proxy_url):
             "socket.create_connection", side_effect=socket.error("test request blocked")
         ) as connect:
             with httpx.Client(proxy=proxy_url) as client:
-                with pytest.raises(httpx.NetworkError):
+                with pytest.raises(httpx.NetworkError):  # pragma: no branch
                     client.get("https://foo.bar/")
         assert connect.called is True
         assert connect_route.called is True
@@ -539,7 +539,7 @@ async def test_proxies(proxy_url):
             side_effect=ConnectionRefusedError("test request blocked"),
         ) as open_connection:
             async with httpx.AsyncClient(proxy=proxy_url) as client:
-                with pytest.raises(httpx.NetworkError):
+                with pytest.raises(httpx.NetworkError):  # pragma: no branch
                     await client.get("https://foo.bar/")
         assert open_connection.called is True
         assert connect_route.called is True

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,4 +1,6 @@
 from contextlib import ExitStack as does_not_raise
+import socket
+from unittest import mock
 
 import httpcore
 import httpx
@@ -473,18 +475,91 @@ def test_add_remove_targets():
         assert len(HTTPCoreMocker.targets) == pre_add_count
 
 
-async def test_proxies():
+@pytest.mark.parametrize("proxy_url", ["http://1.1.1.1:1", "https://1.1.1.1:1"])
+async def test_proxies(proxy_url):
     with respx.mock:
         respx.get("https://foo.bar/") % dict(json={"foo": "bar"})
-        with httpx.Client(proxy="https://1.1.1.1:1") as client:
+        with httpx.Client(proxy=proxy_url) as client:
             response = client.get("https://foo.bar/")
         assert response.json() == {"foo": "bar"}
 
     async with respx.mock:
         respx.get("https://foo.bar/") % dict(json={"foo": "bar"})
-        async with httpx.AsyncClient(proxy="https://1.1.1.1:1") as client:
+        async with httpx.AsyncClient(proxy=proxy_url) as client:
             response = await client.get("https://foo.bar/")
         assert response.json() == {"foo": "bar"}
+
+    with respx.mock:
+        route = respx.route().pass_through()
+        with mock.patch(
+            "socket.create_connection", side_effect=socket.error("test request blocked")
+        ) as connect:
+            with pytest.raises(httpx.NetworkError):
+                with httpx.Client(proxy=proxy_url) as client:
+                    client.get("https://foo.bar/")
+        assert connect.called is True
+        assert route.called is True
+        assert route.calls.last.request.method == "CONNECT"
+
+    async with respx.mock:
+        route = respx.route().pass_through()
+        with mock.patch(
+            "anyio.connect_tcp",
+            side_effect=ConnectionRefusedError("test request blocked"),
+        ) as open_connection:
+            with pytest.raises(httpx.NetworkError):
+                async with httpx.AsyncClient(proxy=proxy_url) as client:
+                    await client.get("https://foo.bar/")
+        assert open_connection.called is True
+        assert route.called is True
+        assert route.calls.last.request.method == "CONNECT"
+
+    with respx.mock:
+        connect_route = respx.route(method="CONNECT", url=f"{proxy_url}/").pass_through()
+        route = respx.get("https://foo.bar/").pass_through()
+        with mock.patch(
+            "socket.create_connection", side_effect=socket.error("test request blocked")
+        ) as connect:
+            with pytest.raises(httpx.NetworkError):
+                with httpx.Client(proxy=proxy_url) as client:
+                    client.get("https://foo.bar/")
+        assert connect.called is True
+        assert connect_route.called is True
+        assert route.called is True
+
+    async with respx.mock:
+        connect_route = respx.route(method="CONNECT", url=f"{proxy_url}/").pass_through()
+        route = respx.get("https://foo.bar/").pass_through()
+        with mock.patch(
+            "anyio.connect_tcp",
+            side_effect=ConnectionRefusedError("test request blocked"),
+        ) as open_connection:
+            with pytest.raises(httpx.NetworkError):
+                async with httpx.AsyncClient(proxy=proxy_url) as client:
+                    await client.get("https://foo.bar/")
+        assert open_connection.called is True
+        assert connect_route.called is True
+        assert route.called is True
+
+    with respx.mock:
+        connect_route = respx.route(method="CONNECT", url=f"{proxy_url}/").mock(
+            return_value=httpx.Response(407)
+        )
+        respx.get("https://foo.bar/").pass_through()
+        with pytest.raises(httpx.ProxyError):
+            with httpx.Client(proxy=proxy_url) as client:
+                client.get("https://foo.bar/")
+        assert connect_route.called is True
+
+    async with respx.mock:
+        connect_route = respx.route(method="CONNECT", url=f"{proxy_url}/").mock(
+            return_value=httpx.Response(407)
+        )
+        respx.get("https://foo.bar/").pass_through()
+        with pytest.raises(httpx.ProxyError):
+            async with httpx.AsyncClient(proxy=proxy_url) as client:
+                await client.get("https://foo.bar/")
+        assert connect_route.called is True
 
 
 async def test_uds():

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,5 +1,5 @@
-from contextlib import ExitStack as does_not_raise
 import socket
+from contextlib import ExitStack as does_not_raise
 from unittest import mock
 
 import httpcore
@@ -494,8 +494,8 @@ async def test_proxies(proxy_url):
         with mock.patch(
             "socket.create_connection", side_effect=socket.error("test request blocked")
         ) as connect:
-            with pytest.raises(httpx.NetworkError):
-                with httpx.Client(proxy=proxy_url) as client:
+            with httpx.Client(proxy=proxy_url) as client:
+                with pytest.raises(httpx.NetworkError):
                     client.get("https://foo.bar/")
         assert connect.called is True
         assert route.called is True
@@ -507,8 +507,8 @@ async def test_proxies(proxy_url):
             "anyio.connect_tcp",
             side_effect=ConnectionRefusedError("test request blocked"),
         ) as open_connection:
-            with pytest.raises(httpx.NetworkError):
-                async with httpx.AsyncClient(proxy=proxy_url) as client:
+            async with httpx.AsyncClient(proxy=proxy_url) as client:
+                with pytest.raises(httpx.NetworkError):
                     await client.get("https://foo.bar/")
         assert open_connection.called is True
         assert route.called is True
@@ -520,8 +520,8 @@ async def test_proxies(proxy_url):
         with mock.patch(
             "socket.create_connection", side_effect=socket.error("test request blocked")
         ) as connect:
-            with pytest.raises(httpx.NetworkError):
-                with httpx.Client(proxy=proxy_url) as client:
+            with httpx.Client(proxy=proxy_url) as client:
+                with pytest.raises(httpx.NetworkError):
                     client.get("https://foo.bar/")
         assert connect.called is True
         assert connect_route.called is True
@@ -534,8 +534,8 @@ async def test_proxies(proxy_url):
             "anyio.connect_tcp",
             side_effect=ConnectionRefusedError("test request blocked"),
         ) as open_connection:
-            with pytest.raises(httpx.NetworkError):
-                async with httpx.AsyncClient(proxy=proxy_url) as client:
+            async with httpx.AsyncClient(proxy=proxy_url) as client:
+                with pytest.raises(httpx.NetworkError):
                     await client.get("https://foo.bar/")
         assert open_connection.called is True
         assert connect_route.called is True
@@ -546,8 +546,8 @@ async def test_proxies(proxy_url):
             return_value=httpx.Response(407)
         )
         respx.get("https://foo.bar/").pass_through()
-        with pytest.raises(httpx.ProxyError):
-            with httpx.Client(proxy=proxy_url) as client:
+        with httpx.Client(proxy=proxy_url) as client:
+            with pytest.raises(httpx.ProxyError):
                 client.get("https://foo.bar/")
         assert connect_route.called is True
 
@@ -556,8 +556,8 @@ async def test_proxies(proxy_url):
             return_value=httpx.Response(407)
         )
         respx.get("https://foo.bar/").pass_through()
-        with pytest.raises(httpx.ProxyError):
-            async with httpx.AsyncClient(proxy=proxy_url) as client:
+        async with httpx.AsyncClient(proxy=proxy_url) as client:
+            with pytest.raises(httpx.ProxyError):
                 await client.get("https://foo.bar/")
         assert connect_route.called is True
 

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -515,7 +515,9 @@ async def test_proxies(proxy_url):
         assert route.calls.last.request.method == "CONNECT"
 
     with respx.mock:
-        connect_route = respx.route(method="CONNECT", url=f"{proxy_url}/").pass_through()
+        connect_route = respx.route(
+            method="CONNECT", url=f"{proxy_url}/"
+        ).pass_through()
         route = respx.get("https://foo.bar/").pass_through()
         with mock.patch(
             "socket.create_connection", side_effect=socket.error("test request blocked")
@@ -528,7 +530,9 @@ async def test_proxies(proxy_url):
         assert route.called is True
 
     async with respx.mock:
-        connect_route = respx.route(method="CONNECT", url=f"{proxy_url}/").pass_through()
+        connect_route = respx.route(
+            method="CONNECT", url=f"{proxy_url}/"
+        ).pass_through()
         route = respx.get("https://foo.bar/").pass_through()
         with mock.patch(
             "anyio.connect_tcp",


### PR DESCRIPTION
This PR addresses an issue where `pass_through` in a proxy environment causes requests to fail:

    $ https_proxy=http://proxy:8080 python
    >>> with respx.mock:
    ...     respx.route().pass_through()
    ...     httpx.get("https://example.com")
    httpx.InvalidURL: Invalid port: '8080example.com:443'

When a proxy is configured, httpcore sends a CONNECT request to establish a tunnel. This request uses authority-form URLs (e.g. `example.com:443`) with no scheme. When respx intercepts this and tries to parse it into an `httpx.URL`, the parser crashes.

This PR fixes the URL construction in `to_httpx_request` so that CONNECT requests flow through the normal route matching system. This means CONNECT tunnels can be mocked just like any other request:

```python
with respx.mock:
    respx.route(method="CONNECT").pass_through()
    respx.get("https://foo.bar/").pass_through()
    httpx.Client(proxy="https://proxy:8080").get("https://foo.bar/")
```

Or mock proxy errors:

```python
with respx.mock:
    respx.route(method="CONNECT").mock(return_value=httpx.Response(407))
    ...
```