### PR TITLE
Fix function introspection on Python 3.14 with deferred annotations (PEP 649)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix `TypeError: unsupported callable` when decorating a function whose parameter is
+  annotated with a name imported only under `if TYPE_CHECKING:`, on Python 3.14 where
+  annotations are evaluated lazily (PEP 649) (#315)
+
 ## [0.23.1] - 2026-04-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `TypeError: unsupported callable` when decorating a function whose parameter is
   annotated with a name imported only under `if TYPE_CHECKING:`, on Python 3.14 where
   annotations are evaluated lazily (PEP 649) (#315)
+- Detect `respx_mock` and `route` parameters declared on functions wrapped with
+  `functools.wraps` by following the `__wrapped__` chain when introspecting decorated
+  callables (#315)
 
 ## [0.23.1] - 2026-04-08
 

--- a/respx/mocks.py
+++ b/respx/mocks.py
@@ -8,6 +8,7 @@ import httpcore
 import httpx
 
 from respx.patterns import parse_url
+from respx.utils import get_arg_spec
 
 from .models import AllMockedAssertionError, PassThrough
 from .transports import TryTransport
@@ -172,7 +173,7 @@ class AbstractRequestMocker(Mocker):
             # Prevent mocking mock
             return spec
 
-        argspec = inspect.getfullargspec(spec)
+        argspec = get_arg_spec(spec)
 
         def mock(self, *args, **kwargs):
             kwargs = cls._merge_args_and_kwargs(argspec, args, kwargs)

--- a/respx/models.py
+++ b/respx/models.py
@@ -16,7 +16,7 @@ from warnings import warn
 
 import httpx
 
-from respx.utils import SetCookie
+from respx.utils import SetCookie, get_arg_spec
 
 from .patterns import M, Pattern
 from .types import (
@@ -330,7 +330,7 @@ class Route:
         self, effect: CallableSideEffect, request: httpx.Request, **kwargs: Any
     ) -> RouteResultTypes:
         # Add route kwarg if the side effect wants it
-        argspec = inspect.getfullargspec(effect)
+        argspec = get_arg_spec(effect)
         if "route" in kwargs:
             warn(f"Matched context contains reserved word `route`: {self.pattern!r}")
         if "route" in argspec.args:

--- a/respx/router.py
+++ b/respx/router.py
@@ -31,6 +31,7 @@ from .models import (
 )
 from .patterns import Pattern, merge_patterns, parse_url_patterns
 from .types import DefaultType, ResolvedResponseTypes, RouteResultTypes, URLPatternTypes
+from .utils import get_arg_spec
 
 Default = NewType("Default", object)
 DEFAULT = Default(...)
@@ -394,7 +395,7 @@ class MockRouter(Router):
 
         # Determine if decorated function needs a `respx_mock` instance
         is_async = inspect.iscoroutinefunction(func)
-        argspec = inspect.getfullargspec(func)
+        argspec = get_arg_spec(func)
         needs_mock_reference = "respx_mock" in argspec.args
 
         if needs_mock_reference:

--- a/respx/utils.py
+++ b/respx/utils.py
@@ -183,7 +183,7 @@ def get_arg_spec(func: Callable[..., Any]) -> ArgSpec:
 
         kwargs["annotation_format"] = annotationlib.Format.FORWARDREF
 
-    signature = inspect.signature(func, follow_wrapped=False, **kwargs)
+    signature = inspect.signature(func, **kwargs)
     positional_kinds = (
         inspect.Parameter.POSITIONAL_ONLY,
         inspect.Parameter.POSITIONAL_OR_KEYWORD,

--- a/respx/utils.py
+++ b/respx/utils.py
@@ -1,9 +1,12 @@
 import email
+import inspect
+import sys
 from collections import defaultdict
 from datetime import datetime
 from email.message import Message
 from typing import (
     Any,
+    Callable,
     Dict,
     Iterable,
     List,
@@ -155,3 +158,45 @@ class SetCookie(
         )
         self = super().__new__(cls, "Set-Cookie", string)
         return self
+
+
+class ArgSpec(NamedTuple):
+    args: List[str]
+    defaults: Optional[Tuple[Any, ...]]
+
+
+def get_arg_spec(func: Callable[..., Any]) -> ArgSpec:
+    """
+    Return the positional parameter names and defaults of a callable.
+
+    Since PEP 649 (Python 3.14) annotations are evaluated lazily, and
+    ``inspect.getfullargspec`` forces that evaluation. A parameter annotated
+    with a name only imported under ``if TYPE_CHECKING:`` then raises
+    ``NameError``, which ``getfullargspec`` re-raises as
+    ``TypeError: unsupported callable``. On Python 3.14+ we therefore read the
+    signature with ``ForwardRef`` placeholders, which never evaluates the
+    annotations.
+    """
+    kwargs: Dict[str, Any] = {}
+    if sys.version_info >= (3, 14):  # pragma: no cover
+        import annotationlib
+
+        kwargs["annotation_format"] = annotationlib.Format.FORWARDREF
+
+    signature = inspect.signature(func, follow_wrapped=False, **kwargs)
+    positional_kinds = (
+        inspect.Parameter.POSITIONAL_ONLY,
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+    )
+    args = [
+        name
+        for name, parameter in signature.parameters.items()
+        if parameter.kind in positional_kinds
+    ]
+    defaults = tuple(
+        parameter.default
+        for parameter in signature.parameters.values()
+        if parameter.kind in positional_kinds
+        and parameter.default is not inspect.Parameter.empty
+    )
+    return ArgSpec(args, defaults or None)

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,4 +1,5 @@
 import socket
+import sys
 from contextlib import ExitStack as does_not_raise
 from unittest import mock
 
@@ -150,6 +151,40 @@ def test_local_decorator_with_reference():
         assert respx_mock is router
 
     test()
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="Deferred annotations (PEP 649) only apply on Python 3.14+. On older "
+    "versions a bare annotation referencing a TYPE_CHECKING-only name raises "
+    "NameError at function definition time, so the scenario cannot be reproduced.",
+)
+def test_decorating_with_type_checking_only_annotation():
+    # Regression for https://github.com/lundberg/respx -- decorating a function
+    # whose parameter is annotated with a name imported only under
+    # `if TYPE_CHECKING:`. On Python 3.14 (PEP 649) the annotation is evaluated
+    # lazily; `inspect.getfullargspec` used to force that evaluation and raise
+    # `TypeError: unsupported callable` (root cause `NameError`).
+    #
+    # The function is built via `exec` so this test module still imports on
+    # Python < 3.14, where the bare annotation would otherwise raise NameError
+    # at definition time.
+    source = (
+        "from typing import TYPE_CHECKING\n"
+        "if TYPE_CHECKING:\n"
+        "    import this_module_is_only_imported_for_typing as typing_only\n"
+        "def func(arg: typing_only.Thing = None, respx_mock=None):\n"
+        "    return arg, respx_mock\n"
+    )
+    namespace: dict = {}
+    exec(compile(source, __file__, "exec"), namespace)
+    func = namespace["func"]
+
+    decorated = respx.mock(func)
+
+    # `respx_mock` is detected and injected despite the unresolved annotation,
+    # and the annotated parameter's default is preserved.
+    assert decorated() == (None, respx.mock)
 
 
 def test_local_decorator_without_reference():

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,3 +1,4 @@
+import functools
 import socket
 import sys
 from contextlib import ExitStack as does_not_raise
@@ -147,6 +148,24 @@ def test_local_decorator_with_reference():
     router = respx.mock()
 
     @router
+    def test(respx_mock):
+        assert respx_mock is router
+
+    test()
+
+
+def test_decorator_follows_wrapped_function():
+    router = respx.mock()
+
+    def passthrough(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    @router
+    @passthrough
     def test(respx_mock):
         assert respx_mock is router
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
+import functools
 from datetime import datetime, timezone
 
-from respx.utils import SetCookie
+from respx.utils import SetCookie, get_arg_spec
 
 
 class TestSetCookie:
@@ -31,3 +32,33 @@ class TestSetCookie:
                 "Partitioned"
             ),
         )
+
+
+class TestGetArgSpec:
+    def test_returns_positional_args_and_defaults(self) -> None:
+        def func(a, b, c=3, *args, d, e=5, **kwargs):  # pragma: no cover
+            ...
+
+        arg_spec = get_arg_spec(func)
+        assert arg_spec.args == ["a", "b", "c"]
+        assert arg_spec.defaults == (3,)
+
+    def test_returns_none_defaults_without_defaults(self) -> None:
+        def func(a, b):  # pragma: no cover
+            ...
+
+        arg_spec = get_arg_spec(func)
+        assert arg_spec.args == ["a", "b"]
+        assert arg_spec.defaults is None
+
+    def test_ignores_wrapped_chain(self) -> None:
+        def inner(a, b, respx_mock=None):  # pragma: no cover
+            ...
+
+        @functools.wraps(inner)
+        def wrapper(*args, **kwargs):  # pragma: no cover
+            ...
+
+        arg_spec = get_arg_spec(wrapper)
+        assert arg_spec.args == []
+        assert arg_spec.defaults is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,7 +51,7 @@ class TestGetArgSpec:
         assert arg_spec.args == ["a", "b"]
         assert arg_spec.defaults is None
 
-    def test_ignores_wrapped_chain(self) -> None:
+    def test_follows_wrapped_chain(self) -> None:
         def inner(a, b, respx_mock=None):  # pragma: no cover
             ...
 
@@ -59,6 +59,8 @@ class TestGetArgSpec:
         def wrapper(*args, **kwargs):  # pragma: no cover
             ...
 
+        # Follows __wrapped__ (inspect.signature's default) so respx detects
+        # respx_mock / route declared on a wrapped function.
         arg_spec = get_arg_spec(wrapper)
-        assert arg_spec.args == []
-        assert arg_spec.defaults is None
+        assert arg_spec.args == ["a", "b", "respx_mock"]
+        assert arg_spec.defaults == (None,)


### PR DESCRIPTION
Closes #322.

## Summary

On Python 3.14, [PEP 649](https://peps.python.org/pep-0649/) makes annotations
evaluated lazily. respx introspects decorated callables (and side effects) with
`inspect.getfullargspec(...)` to detect parameters such as `respx_mock` and `route` —
but `getfullargspec` *forces* annotation evaluation, so a parameter annotated with a
`TYPE_CHECKING`-only name raises `NameError`, re-raised as
`TypeError: unsupported callable` (see #322 for a full repro/traceback).

This replaces `getfullargspec` with a small helper, `respx.utils.get_arg_spec()`, used
at all three call sites (`router.py`, `models.py`, `mocks.py`).

## How

respx only needs the positional parameter **names** and their **defaults** — never the
annotation values. `get_arg_spec` derives those from `inspect.signature()`:

- On **Python 3.14+** it passes `annotation_format=annotationlib.Format.FORWARDREF`, so
  unresolved (`TYPE_CHECKING`-only) names degrade to `ForwardRef` placeholders instead
  of raising.
- On **older Pythons** it falls back to plain `inspect.signature()`, which yields
  identical `args`/`defaults`. (`annotationlib` and the `annotation_format` argument are
  3.14+, so they're version-guarded.)

## Bonus: detect parameters through wrapping decorators

`inspect.getfullargspec` ignored `__wrapped__`, whereas `inspect.signature` follows it by
default — so as a side benefit, respx now detects `respx_mock` / `route` declared on
functions wrapped with `functools.wraps` (e.g. `@respx.mock` stacked on top of another
decorator). Previously the wrapper's `(*args, **kwargs)` signature hid the parameter, so
respx didn't inject it and the call failed with a missing-argument `TypeError`. This is
also consistent with how respx itself uses `functools.wraps` / `update_wrapper` on its
own decorators.

The two changes are in **separate commits** (the crash fix, then the `wraps` behavior),
so they can be reviewed or taken independently.

## Compatibility

No public API change. Supported Python versions (3.8–3.14) are unaffected; the
`annotationlib` path is guarded by `sys.version_info >= (3, 14)`, and mypy
(`python_version = 3.10`) passes clean.

## Tests

- Regression test decorating a function with a `TYPE_CHECKING`-only-typed parameter
  (skipped on < 3.14, where the scenario can't occur).
- Unit tests for `get_arg_spec` (args/defaults extraction and `__wrapped__` following).
- End-to-end test that `respx_mock` is injected through a wrapping decorator.
- Full suite: **326 passed, 100% coverage**; mypy clean.
